### PR TITLE
Use tools.reader to read expressions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [org.clojure/tools.nrepl "0.2.3"]
-                 [org.clojure/clojurescript "0.0-2014"]]
+                 [org.clojure/clojurescript "0.0-2080"]]
   
   :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}
   


### PR DESCRIPTION
Use a source-logging-pushback-reader in order to
preserve source information for sending sourcemaps
to the browser.

Fixes #19 - Uses the compiler environment and
makes sure to bring in the proper requires for
aliases. It would be nice to just use `form-seq` but
if multiple forms are entered, the resulting sourcemaps
from `evaluate-form` would be incorrect as the reader
needs to be initialized with line 1, column 1 for each form.
