### PR TITLE
Pass file-path instead of file-name into cljs.repl/load-stream

### DIFF
--- a/src/cemerick/piggieback.clj
+++ b/src/cemerick/piggieback.clj
@@ -133,7 +133,7 @@
 (defn- load-file-contents
   [repl-env code file-path file-name]
   (binding [ana/*cljs-ns* 'cljs.user]
-    (cljs.repl/load-stream repl-env file-name (java.io.StringReader. code))))
+    (cljs.repl/load-stream repl-env file-path (java.io.StringReader. code))))
 
 (defn- load-file-code
   [code file-path file-name]


### PR DESCRIPTION
This is the last piece of the puzzle for cider's jump-to-definition support, along with http://dev.clojure.org/jira/browse/CLJS-764
