### PR TITLE
Bump Clojurescript for JDK 9 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: clojure
-lein: lein2
-script: "lein2 all do clean, test"
+script: "lein all do clean, test"
 jdk:
   - openjdk7
   - oraclejdk7
   - oraclejdk8
+  - oraclejdk9

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.8.0" :scope "provided"]
                  [org.clojure/tools.nrepl "0.2.10"]
-                 [org.clojure/clojurescript "1.9.946"]]
+                 [org.clojure/clojurescript "1.10.238"]]
 
   :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}
 


### PR DESCRIPTION
This PR bumps the Clojurescript version for JDK 9 compatibility. It also fixes the travis config to use lein instead of lein2.

Fixes : #77 

Build failure related to repl output : https://travis-ci.org/tirkarthi/piggieback/jobs/359727935