### PR TITLE
Add compatibility with nREPL 0.4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject cider/piggieback "0.3.6"
+(defproject cider/piggieback "0.3.7-SNAPSHOT"
   :description "Middleware adding support for running ClojureScript REPLs over nREPL."
   :url "http://github.com/nrepl/piggieback"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :min-lein-version "2.0.0"
-  :dependencies [[org.clojure/tools.nrepl "0.2.13"]
+  :dependencies [[nrepl/nrepl "0.4.3"]
                  [org.clojure/clojure "1.8.0"]
                  [org.clojure/clojurescript "1.9.946"]]
 

--- a/src/cider/piggieback.clj
+++ b/src/cider/piggieback.clj
@@ -1,12 +1,7 @@
 (ns cider.piggieback
   "nREPL middleware enabling the transparent use of a ClojureScript REPL with nREPL tooling."
   {:author "Chas Emerick"}
-  (:require [clojure.tools.nrepl :as nrepl]
-            (clojure.tools.nrepl [transport :as transport]
-                                 [misc :refer (response-for)]
-                                 [middleware :refer (set-descriptor!)])
-            [clojure.tools.nrepl.middleware.interruptible-eval :as ieval]
-            [clojure.java.io :as io]
+  (:require [clojure.java.io :as io]
             cljs.repl
             [cljs.env :as env]
             [cljs.analyzer :as ana]
@@ -17,6 +12,23 @@
   (:import java.io.StringReader
            java.io.Writer)
   (:refer-clojure :exclude (load-file)))
+
+;; Compatibility with the legacy tools.nrepl and the new nREPL 0.4.x.
+;; The assumption is that if someone is using old lein repl or boot repl
+;; they'll end up using the tools.nrepl, otherwise the modern one.
+(if (find-ns 'clojure.tool.nrepl)
+  (require
+   '[clojure.tools.nrepl :as nrepl]
+   '[clojure.tools.nrepl.middleware :as middleware :refer (set-descriptor!)]
+   '[clojure.tools.nrepl.middleware.interruptible-eval :as ieval]
+   '[clojure.tools.nrepl.misc :as misc :refer (response-for)]
+   '[clojure.tools.nrepl.transport :as transport])
+  (require
+   '[nrepl.core :as nrepl]
+   '[nrepl.middleware :as middleware :refer (set-descriptor!)]
+   '[nrepl.middleware.interruptible-eval :as ieval]
+   '[nrepl.misc :as misc :refer (response-for)]
+   '[nrepl.transport :as transport]))
 
 ;; this is the var that is checked by the middleware to determine whether an
 ;; active CLJS REPL is in flight

--- a/test/cider/piggieback_test.clj
+++ b/test/cider/piggieback_test.clj
@@ -1,7 +1,7 @@
 (ns cider.piggieback-test
   (:require [cider.piggieback :as pb]
-            [clojure.tools.nrepl :as nrepl]
-            (clojure.tools.nrepl [server :as server]))
+            [nrepl.core :as nrepl]
+            [nrepl.server :as server])
   (:use clojure.test))
 
 (def ^:dynamic *server-port* nil)
@@ -35,7 +35,7 @@
   (with-open [server (server/start-server
                       :bind "127.0.0.1"
                       :handler (server/default-handler #'cider.piggieback/wrap-cljs-repl))]
-    (let [port (.getLocalPort (:ss @server))
+    (let [port (.getLocalPort (:server-socket server))
           conn (nrepl/connect :port port)
           session (nrepl/client-session (nrepl/client conn Long/MAX_VALUE))]
       ;; need to let the dynamic bindings get in place before trying to eval anything that


### PR DESCRIPTION
Now that lein is switching to nREPL 0.4 really soon (https://github.com/technomancy/leiningen/pull/2444 was just merged) it's time to upgrade piggieback and related tools to work with nREPL 0.4 as well. 

@bhauman @thheller take a look at the approach I've taken here to retain compatibilities with both nREPL for piggieback. Probably you'll have to do something similar for figwheel and shadow-cljs. 