### PR TITLE
Read multiple forms from input

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## `Master`
+
+* [#98](https://github.com/nrepl/piggieback/pull/98): Read multiple forms from input.
+
 ## `0.3.10`
 
 * [#95](https://github.com/nrepl/piggieback/issues/95): Bind `*cljs-warnings*`.

--- a/test/cider/piggieback_test.clj
+++ b/test/cider/piggieback_test.clj
@@ -119,3 +119,9 @@
   (is (-> (nrepl/message *session* {:op "eval" :code "(defprotocol Foo [do-a-thing [this]])"})
           nrepl/combine-responses
           :value)))
+
+(deftest handles-multiple-forms
+  (is (= ["#'cljs.user/x" "#'cljs.user/y"]
+         (-> (nrepl/message *session* {:op "eval" :code "(def x 1) (def y 2)" :ns "cljs.user"})
+             nrepl/combine-responses
+             :value))))


### PR DESCRIPTION
This updates clojurescript repls to behave the same as clojure repls when multiple forms are entered. This is especially helpful when pasting code into a repl. Currently only the first form is evaluated. This patch loops over the read forms evaluating them in turn.

```clojure
cljs.user> 
(declare is-odd?)
(defn is-even? [n] (if (= n 0) true (is-odd? (dec n))))
(defn is-odd? [n] (if (= n 0) false (is-even? (dec n))))
#'cljs.user/is-odd?
#'cljs.user/is-even?
#'cljs.user/is-odd?
cljs.user> (is-even? 4)
true
```

Compared to the current behavior:
```clojure
cljs.user> 
(declare is-odd?)
(defn is-even? [n] (if (= n 0) true (is-odd? (dec n))))
(defn is-odd? [n] (if (= n 0) false (is-even? (dec n))))
#'cljs.user/is-odd?
cljs.user> (is-even? 4)
Compile Warning   <cljs repl>   line:1  column:2

  Use of undeclared Var cljs.user/is-even?

  1  (is-even? 4)
      ^---

#object[TypeError TypeError: Cannot read property 'call' of undefined]
	 (<NO_SOURCE_FILE>)
cljs.user> 
```

NREPL cranks up a clojure.main/repl for each message which reads the input string until an EOF so this should match it. If anyone has thoughts about the flush and swaps involved here I'm all ears.