### PR TITLE
Acknowledge cljs dependency in `tools.deps` docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ Then you can simply run a ClojureScript capable nREPL like this:
 clj -R:nrepl -m nrepl.cmdline --middleware "[cider.piggieback/wrap-cljs-repl]"
 ```
 
+Note that Piggieback assumes that the `cljs` library is available when it runs,
+so this command only works if you are in a directory containing a `deps.edn`
+that references `org.clojure/clojurescript`. Alternatively, you can pass the
+dependency to `clj` as an argument:
+
+```shell
+clj -R:nrepl -Sdeps '{:deps {org.clojure/clojurescript {:mvn/version "1.10.520"}}}' \
+  -m nrepl.cmdline --middleware "[cider.piggieback/wrap-cljs-repl]"
+```
+
 Afterwards simply connect to the running server with your favourite
 nREPL client (e.g. CIDER).
 


### PR DESCRIPTION
When I followed the instructions to run an nREPL using `clj` I got a compilation error containing the following message:

```
java.io.FileNotFoundException: Could not locate clojure/tools/reader__init.class, clojure/tools/reader.clj or clojure/tools/reader.cljc on classpath.
```

Adding a `deps.edn` dependency on `clojure.tools.reader` fixes that, but reveals another dependency error. It eventually becomes clear that Piggieback simply depends on ClojureScript.

Add a note to the `README` to help the next person.