### PR TITLE
README: Add notes about starting CLJS REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,15 @@ Add this alias to `~/.clojure/deps.edn`:
 }
 ```
 
-Then you can simply run a ClojureScript capable nREPL like this:
+Then you can simply run a ClojureScript-capable nREPL server like this:
 
 ``` shell
 clj -R:nrepl -m nrepl.cmdline --middleware "[cider.piggieback/wrap-cljs-repl]"
 ```
 
-Afterwards simply connect to the running server with your favourite
-nREPL client (e.g. CIDER).
+When you connect to the running server with with your favourite nREPL client
+(e.g. CIDER), you will be greeted by a Clojure REPL. Within this Clojure REPL,
+you can now [start a ClojureScript REPL](#usage).
 
 ### Embedded
 
@@ -116,6 +117,10 @@ nREPL handler.  Keep two things in mind when doing so:
 
 
 ## Usage
+
+Before you run the following, you must have gone through the [setup
+steps](#installation). Instead of using `lein repl`, you might also connect to a
+headless nREPL using your development environment.
 
 ```
 $ lein repl


### PR DESCRIPTION
When I tried to set up a CLJS REPL in Cursive for the first time, I only
followed the instructions in section ‘Installation’. It didn't work.
Then I went only through a variation of the steps in section ‘Usage’. It
didn't work. Then I became hysterical and tried anything and looked
everywhere I could think of. Finally I realized that I needed to start
an nREPL, then connect to it, then start the CLJS REPL within it.

Add a few sentences that will hopefully save other people a similar
odyssey.