### PR TITLE
Adding nREPL 0.7 and Java 13 to the test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ defaults: &defaults
     LEIN_ROOT: "true"   # we intended to run lein as root
     JVM_OPTS: -Xmx3200m # limit the maximum heap size to prevent out of memory errors
 
-# Runners for OpenJDK 8 and 11
+# Runners for OpenJDK 8, 11 and 14
 
 executors:
   openjdk8:
@@ -25,9 +25,9 @@ executors:
     docker:
       - image: circleci/clojure:openjdk-11-lein-2.9.1
     <<: *defaults
-  openjdk13:
+  openjdk14:
     docker:
-      - image: circleci/clojure:openjdk-13-lein-2.9.1-buster
+      - image: circleci/clojure:openjdk-14-lein-2.9.1-buster
     <<: *defaults
 
 # Runs a given set of steps, with some standard pre- and post-
@@ -133,7 +133,7 @@ jobs:
 # The ci-test-matrix does the following:
 #
 # - run tests against the target matrix
-#   - Java 8, 11 and 13
+#   - Java 8, 11 and 14
 #   - Clojure 1.8, 1.9, 1.10, master
 # - linter, eastwood and cljfmt
 # - runs code coverage report
@@ -175,21 +175,21 @@ workflows:
           clojure_version: "master"
           jdk_version: openjdk11
       - test_code:
-          name: Java 13, Clojure 1.8
+          name: Java 14, Clojure 1.8
           clojure_version: "1.8"
-          jdk_version: openjdk13
+          jdk_version: openjdk14
       - test_code:
-          name: Java 13, Clojure 1.9
+          name: Java 14, Clojure 1.9
           clojure_version: "1.9"
-          jdk_version: openjdk13
+          jdk_version: openjdk14
       - test_code:
-          name: Java 13, Clojure 1.10
+          name: Java 14, Clojure 1.10
           clojure_version: "1.10"
-          jdk_version: openjdk13
+          jdk_version: openjdk14
       - test_code:
-          name: Java 13, Clojure master
+          name: Java 14, Clojure master
           clojure_version: "master"
-          jdk_version: openjdk13
+          jdk_version: openjdk14
       - util_job:
           name: Code Linting
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,10 @@ executors:
     docker:
       - image: circleci/clojure:openjdk-11-lein-2.9.1
     <<: *defaults
+  openjdk13:
+    docker:
+      - image: circleci/clojure:openjdk-13-lein-2.9.1-buster
+    <<: *defaults
 
 # Runs a given set of steps, with some standard pre- and post-
 # steps, including restoring of cache, saving of cache.
@@ -129,7 +133,7 @@ jobs:
 # The ci-test-matrix does the following:
 #
 # - run tests against the target matrix
-#   - Java 8 and 11
+#   - Java 8, 11 and 13
 #   - Clojure 1.8, 1.9, 1.10, master
 # - linter, eastwood and cljfmt
 # - runs code coverage report
@@ -170,6 +174,22 @@ workflows:
           name: Java 11, Clojure master
           clojure_version: "master"
           jdk_version: openjdk11
+      - test_code:
+          name: Java 13, Clojure 1.8
+          clojure_version: "1.8"
+          jdk_version: openjdk13
+      - test_code:
+          name: Java 13, Clojure 1.9
+          clojure_version: "1.9"
+          jdk_version: openjdk13
+      - test_code:
+          name: Java 13, Clojure 1.10
+          clojure_version: "1.10"
+          jdk_version: openjdk13
+      - test_code:
+          name: Java 13, Clojure master
+          clojure_version: "master"
+          jdk_version: openjdk13
       - util_job:
           name: Code Linting
           steps:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ VERSION ?= 1.10
 
 test:
 	set -e; set -x; \
-	for v in "nrepl-0.4" "nrepl-0.5" "nrepl-0.6"; do \
+	for v in "nrepl-0.4" "nrepl-0.5" "nrepl-0.6" "nrepl-0.7"; do \
 	  lein with-profile +$(VERSION),+$$v test; \
 	done;
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Add this alias to `~/.clojure/deps.edn`:
 ;; ...
 :aliases {:nrepl
           {:extra-deps
-            {nrepl/nrepl {:mvn/version "0.6.0"}
+            {nrepl/nrepl {:mvn/version "0.7.0"}
              cider/piggieback {:mvn/version "0.4.2"}}}}
 }
 ```

--- a/project.clj
+++ b/project.clj
@@ -37,6 +37,7 @@
              :nrepl-0.4 {:dependencies [[nrepl/nrepl "0.4.5"]]}
              :nrepl-0.5 {:dependencies [[nrepl/nrepl "0.5.3"]]}
              :nrepl-0.6 {:dependencies [[nrepl/nrepl "0.6.0"]]}
+             :nrepl-0.7 {:dependencies [[nrepl/nrepl "0.7.0"]]}
 
              ;; Need ^:repl because of: https://github.com/technomancy/leiningen/issues/2132
              :repl ^:repl [:test


### PR DESCRIPTION
Catching up with the new versions. Not dropping any older versions... yet.

The tests look healthy, so good basis for debugging flaky tests in #108 