### PR TITLE
Require cljs.repl and cljs.pprint into cljs.user

### DIFF
--- a/src/cider/piggieback_impl.clj
+++ b/src/cider/piggieback_impl.clj
@@ -159,7 +159,10 @@
       (run-cljs-repl ieval/*msg*
                      ;; this is needed to respect :repl-requires
                      (if-let [requires (not-empty (:repl-requires opts))]
-                       (pr-str (cons 'ns `(cljs.user (:require ~@requires))))
+                       (pr-str (cons 'ns `(cljs.user (:require ~@requires
+                                                               [~'cljs.repl :refer-macros [~'source ~'doc ~'find-doc
+                                                                                           ~'apropos ~'dir ~'pst]]
+                                                               [~'cljs.pprint]))))
                        (nrepl/code (ns cljs.user
                                      (:require [cljs.repl :refer-macros [source doc find-doc
                                                                          apropos dir pst]]


### PR DESCRIPTION
in the case that the repl-env specifies :repl-requires.

Some repl-env implementations specify namespaces that need to be required, e.g.
the browser repl-env requires cljs.browser.repl. When this is that case then we
were not loading cljs.user and cljs.pprint, the latter is a problem, because it
is used when evaluating forms. The net result is that when using the browser
cljs repl type, every evaluation causes an exception because cljs.pprint is not
defined.

This fixes that by loading the namespaces we load when :repl-requires isn't
specified, also in the case when :repl-requires is specified.