### PR TITLE
Address reflection warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,6 @@ cloverage:
 	set -e; set -x; \
 	for v in "nrepl-0.6" "nrepl-0.7"; do \
 	  lein with-profile -user,+$(VERSION),+$$v,+cloverage cloverage; \
-	  if [ ! -z $$CI ] ;\
-	    then bash <(curl -s https://codecov.io/bash) -f target/coverage/codecov.json ; \
-	  fi ; \
 	done;
 
 # When releasing, the BUMP variable controls which field in the

--- a/Makefile
+++ b/Makefile
@@ -5,20 +5,20 @@ VERSION ?= 1.10
 test:
 	set -e; set -x; \
 	for v in "nrepl-0.6" "nrepl-0.7"; do \
-	  lein with-profile +$(VERSION),+$$v test; \
+	  lein with-profile -user,+$(VERSION),+$$v test; \
 	done;
 
 eastwood:
-	lein with-profile +$(VERSION),+eastwood eastwood
+	lein with-profile -user,+$(VERSION),+eastwood eastwood
 
 cljfmt:
-	lein with-profile +$(VERSION),+cljfmt cljfmt check
+	lein with-profile -user,+$(VERSION),+cljfmt cljfmt check
 
 cloverage: SHELL := /bin/bash
 cloverage:
 	set -e; set -x; \
 	for v in "nrepl-0.6" "nrepl-0.7"; do \
-	  lein with-profile +$(VERSION),+$$v,+cloverage cloverage; \
+	  lein with-profile -user,+$(VERSION),+$$v,+cloverage cloverage; \
 	  if [ ! -z $$CI ] ;\
 	    then bash <(curl -s https://codecov.io/bash) -f target/coverage/codecov.json ; \
 	  fi ; \
@@ -31,14 +31,14 @@ cloverage:
 BUMP ?= patch
 
 release:
-	lein with-profile +$(VERSION) release $(BUMP)
+	lein with-profile -user,+$(VERSION) release $(BUMP)
 
 # Deploying requires the caller to set environment variables as
 # specified in project.clj to provide a login and password to the
 # artifact repository.
 
 deploy:
-	lein with-profile +$(VERSION) deploy clojars
+	lein with-profile -user,+$(VERSION) deploy clojars
 
 clean:
 	lein clean

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![CircleCI](https://circleci.com/gh/nrepl/piggieback/tree/master.svg?style=svg)](https://circleci.com/gh/nrepl/piggieback/tree/master)
-[![codecov](https://codecov.io/gh/nrepl/piggieback/branch/master/graph/badge.svg)](https://codecov.io/gh/nrepl/piggieback)
 [![Clojars Project](https://img.shields.io/clojars/v/cider/piggieback.svg)](https://clojars.org/cider/piggieback)
 
 # Piggieback

--- a/project.clj
+++ b/project.clj
@@ -51,6 +51,7 @@
 
              :cljfmt {:plugins [[lein-cljfmt "0.6.1"]]}
 
-             :eastwood {:plugins  [[jonase/eastwood "0.3.4"]]
+             :eastwood {:plugins  [[jonase/eastwood "0.7.1"]]
+                        :global-vars {*warn-on-reflection* true}
                         :eastwood {:config-files ["eastwood.clj"]
                                    :exclude-linters [:no-ns-form-found]}}})

--- a/test/cider/piggieback_test.clj
+++ b/test/cider/piggieback_test.clj
@@ -23,10 +23,11 @@
 
 (defn repl-server-fixture
   [f]
-  (with-open [server (server/start-server
+  (with-open [^nrepl.server.Server
+              server (server/start-server
                       :bind "127.0.0.1"
                       :handler (server/default-handler #'cider.piggieback/wrap-cljs-repl))]
-    (let [port (.getLocalPort (:server-socket server))
+    (let [port (.getLocalPort ^java.net.ServerSocket (:server-socket server))
           conn (nrepl/connect :port port)
           session (nrepl/client-session (nrepl/client conn Long/MAX_VALUE))]
       ;; need to let the dynamic bindings get in place before trying to eval anything that


### PR DESCRIPTION
* Makefile: always use `-user` profile
  * Increases reproducibility.
* Remove codecov
* Upgrade Eastwood
* Address reflection warnings in tests
* Address reflection warnings in source by introducing an accessor protocol