### PR TITLE
Restore compatibility with nREPL 1.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ workflows:
             parameters:
               jdk_version: [openjdk8, openjdk11, openjdk17]
               clojure_version: ["1.10", "1.11", "1.12"]
-              nrepl_version: ["nrepl-1.0", "nrepl-1.1", "nrepl-1.2"]
+              nrepl_version: ["nrepl-1.0", "nrepl-1.1", "nrepl-1.2", "nrepl-1.3"]
       - util_job:
           name: Code Linting
           steps:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 * Bump minimal supported nREPL version to 1.0.
 * Bump minimal supported Clojure and ClojureScript versions to 1.10.
+* Restore compatibility with nREPL 1.3.
 
 ## 0.5.3 (2021-10-26)
 

--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
              :test {:source-paths ["env/test"]}
 
              :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]
-                                   [org.clojure/clojurescript "1.10.63"]]}
+                                   [org.clojure/clojurescript "1.10.914"]]}
 
              :1.11 {:dependencies [[org.clojure/clojure "1.11.4"]
                                    [org.clojure/clojurescript "1.11.132"]]}


### PR DESCRIPTION
After nREPL 1.3 majorly changed the way how sessions and session-bound dynamic vars are implemented, Piggieback's rather unorthodox interaction with sessions apparently got broken. This PR attempts to fix it at least at the superficial test level. I honestly tried to understand how things work here between `*ns*`, `*original-clj-ns*`, `cljs.analyzer/*cljs-ns*`, and it's just a big ball of incomprehensible mud to me. I might have sidestepped some things and the tests work now, but I'll have to defer to somebody who actually uses CLJS and understands this stuff.

My only solace is that it's probably not worse than how Piggieback works (or doesn't work) with nREPL 1.3 right now.