### PR TITLE
Route ClojureScript output to the evaluating message

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+* [#111](https://github.com/nrepl/piggieback/issues/111): Fix ClojureScript output being tagged with the REPL-starting message's id and vanishing after reconnecting to a session.
+
 ## 0.6.1 (2025-12-31)
 
 * [132](https://github.com/nrepl/piggieback/pull/132): Fix current namespace dropping back to previous after in-ns.

--- a/src/cider/piggieback_impl.clj
+++ b/src/cider/piggieback_impl.clj
@@ -30,6 +30,45 @@
 (def ^:private ^:dynamic *cljs-warning-handlers* nil)
 (def ^:private ^:dynamic *original-clj-ns* nil)
 
+;; Atoms holding the Writer that the ClojureScript repl env's output should be
+;; forwarded to. They are repointed at the current message's output on every
+;; evaluation, see `forwarding-writer` and issue #111 for the details.
+(def ^:private ^:dynamic *cljs-out-target* nil)
+(def ^:private ^:dynamic *cljs-err-target* nil)
+
+(defn- forwarding-writer
+  "Return a `java.io.Writer` that always delegates to the Writer currently held
+  in `target` (an atom).
+
+  ClojureScript repl envs (e.g. the Node env) capture `*out*` once, at setup
+  time, on the thread that pumps the JS runtime's output back to the user. Bound
+  via `bound-fn`, that thread keeps writing to the output of the message that
+  *started* the REPL, so every later evaluation's output ends up with the wrong
+  message id and vanishes entirely once that connection is closed (issue #111).
+  Handing the env a forwarding writer lets us repoint it at the current
+  message's output on each evaluation."
+  ^java.io.Writer [target]
+  (proxy [java.io.Writer] []
+    ;; The proxy routes every `write` overload (and, via the superclass'
+    ;; `append`, those too) through this fn, so we have to cover both the
+    ;; single-argument and the (data, off, len) arities and dispatch on type.
+    (write
+      ([x]
+       (let [^java.io.Writer w @target]
+         (cond
+           (integer? x) (.write w (int x))
+           (string? x) (.write w ^String x)
+           :else (.write w ^chars x))))
+      ([data off len]
+       (let [^java.io.Writer w @target]
+         (if (string? data)
+           (.write w ^String data (int off) (int len))
+           (.write w ^chars data (int off) (int len))))))
+    (flush [] (.flush ^java.io.Writer @target))
+    ;; Deliberately a flush, not a close: the underlying per-message writers are
+    ;; owned and closed by nREPL, we must not close them here.
+    (close [] (.flush ^java.io.Writer @target))))
+
 ;; ---------------------------------------------------------------------------
 ;; Delegating Repl Env
 ;; ---------------------------------------------------------------------------
@@ -161,19 +200,28 @@
                  (merge-with (fn [a b] (if (nil? b) a b))
                              repl-opts options)))]
       (set! ana/*cljs-ns* 'cljs.user)
-      ;; this will implicitly set! *cljs-compiler-env*
-      (run-cljs-repl ieval/*msg*
-                     ;; this is needed to respect :repl-requires
-                     (if-let [requires (not-empty (:repl-requires opts))]
-                       (pr-str (cons 'ns `(cljs.user (:require ~@requires
-                                                               [~'cljs.repl :refer-macros [~'source ~'doc ~'find-doc
-                                                                                           ~'apropos ~'dir ~'pst]]
-                                                               [~'cljs.pprint]))))
-                       (nrepl/code (ns cljs.user
-                                     (:require [cljs.repl :refer-macros [source doc find-doc
-                                                                         apropos dir pst]]
-                                               [cljs.pprint]))))
-                     repl-env nil options)
+      (let [out-target (atom *out*)
+            err-target (atom *err*)]
+        ;; Set up the repl env with forwarding writers in place so its
+        ;; output-pump thread forwards to the current message's output rather
+        ;; than to the one that started the REPL (issue #111).
+        (binding [*out* (forwarding-writer out-target)
+                  *err* (forwarding-writer err-target)]
+          ;; this will implicitly set! *cljs-compiler-env*
+          (run-cljs-repl ieval/*msg*
+                         ;; this is needed to respect :repl-requires
+                         (if-let [requires (not-empty (:repl-requires opts))]
+                           (pr-str (cons 'ns `(cljs.user (:require ~@requires
+                                                                   [~'cljs.repl :refer-macros [~'source ~'doc ~'find-doc
+                                                                                               ~'apropos ~'dir ~'pst]]
+                                                                   [~'cljs.pprint]))))
+                           (nrepl/code (ns cljs.user
+                                         (:require [cljs.repl :refer-macros [source doc find-doc
+                                                                             apropos dir pst]]
+                                                   [cljs.pprint]))))
+                         repl-env nil options))
+        (set! *cljs-out-target* out-target)
+        (set! *cljs-err-target* err-target))
       ;; (clojure.pprint/pprint (:options @*cljs-compiler-env*))
       (set! *cljs-repl-env* repl-env)
       (set! *cljs-repl-options* opts)
@@ -276,6 +324,9 @@
                         (when ns
                           {#'ana/*cljs-ns* (symbol ns)})
                         (output-bindings msg))
+    ;; Repoint the repl env's output-pump thread at this message's output (#111).
+    (when *cljs-out-target* (reset! *cljs-out-target* *out*))
+    (when *cljs-err-target* (reset! *cljs-err-target* *err*))
     (let [repl-env *cljs-repl-env*
           repl-options *cljs-repl-options*
           init-ns ana/*cljs-ns*
@@ -365,6 +416,8 @@
                                        #'*cljs-repl-options* *cljs-repl-options*
                                        #'*cljs-warnings* *cljs-warnings*
                                        #'*cljs-warning-handlers* *cljs-warning-handlers*
+                                       #'*cljs-out-target* *cljs-out-target*
+                                       #'*cljs-err-target* *cljs-err-target*
                                        #'*original-clj-ns* *ns*
                                        #'ana/*cljs-ns* ana/*cljs-ns*})))
       (handler msg))))

--- a/test/cider/piggieback_test.clj
+++ b/test/cider/piggieback_test.clj
@@ -111,3 +111,45 @@
                      nrepl/combine-responses)]
     (testing (pr-str response)
       (is (= "cljs.user" (:ns response))))))
+
+;; The forwarding writer stands in for *out*/*err* while the repl env is set up,
+;; so it must cope with every way Clojure and the repl env write to it, not just
+;; the (char[], off, len) arity the Node output pump happens to use.
+(deftest forwarding-writer-handles-all-write-arities
+  (let [sink (java.io.StringWriter.)
+        ^java.io.Writer fw (#'cider.piggieback/forwarding-writer (atom sink))]
+    (.write fw (int \A))
+    (.write fw "bc")
+    (.write fw (char-array "de"))
+    (.write fw "XfgY" 1 2)
+    (.append fw \h)
+    (.append fw "ij")
+    (binding [*out* fw] (print "k") (pr {:l 1}) (flush))
+    (is (= "Abcdefghijk{:l 1}" (str sink)))))
+
+;; Regression test for https://github.com/nrepl/piggieback/issues/111
+;;
+;; ClojureScript output used to be tagged with the message that started the REPL
+;; instead of the message that produced it, so `nrepl/message` (which filters by
+;; id) never saw it, and it vanished entirely once that connection was closed.
+;;
+;; The reconnection case is exercised over a fresh connection to the SAME server
+;; and session as the fixture; spinning up a second `cljs.repl.node` REPL in the
+;; same JVM is not an option, as the Node env keys its eval state on a global
+;; that collapses all nREPL threads together.
+(deftest output-routing
+  (testing "output arrives associated with the evaluating message, not the REPL-starting one"
+    (let [response (-> (nrepl/message *session* {:op "eval" :code "(println \"hey\")"})
+                       nrepl/combine-responses)]
+      (testing (pr-str response)
+        (is (= "hey\n" (:out response))))))
+
+  (testing "output still arrives after reconnecting to the session on a new connection"
+    (let [sess-id (-> (nrepl/message *session* {:op "eval" :code "1"}) first :session)]
+      (with-open [^java.io.Closeable conn (nrepl/connect :port *server-port*)]
+        (let [session (nrepl/client-session (nrepl/client conn Long/MAX_VALUE)
+                                            :session sess-id)
+              response (-> (nrepl/message session {:op "eval" :code "(println \"reconnected\")"})
+                           nrepl/combine-responses)]
+          (testing (pr-str response)
+            (is (= "reconnected\n" (:out response)))))))))


### PR DESCRIPTION
ClojureScript repl envs (the Node env, and others) capture `*out*`/`*err*` once, at setup time, on the thread that pumps the JS runtime's output back to the user. Because that thread is started with `bound-fn`, it kept writing to the output of the message that *started* the REPL - so every later evaluation's output came back with the wrong message id (clients filter by id, so editors never saw it) and disappeared completely once that original connection was closed.

The fix hands the env writers that forward to a per-evaluation target, and repoints that target at the current message's output on each eval. Output now follows the evaluating message and survives reconnecting to a session.

Includes a regression test (it fails without the change). Fixes #111.