### PR TITLE
Record the compiler env even when REPL setup errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+* [#62](https://github.com/nrepl/piggieback/issues/62): Keep evaluation working after a REPL setup error by always recording the compiler env.
 * [#111](https://github.com/nrepl/piggieback/issues/111): Fix ClojureScript output being tagged with the REPL-starting message's id and vanishing after reconnecting to a session.
 
 ## 0.6.1 (2025-12-31)

--- a/src/cider/piggieback_impl.clj
+++ b/src/cider/piggieback_impl.clj
@@ -198,7 +198,12 @@
                 {:def-emits-var true}
                 (cljs.closure/add-implicit-options
                  (merge-with (fn [a b] (if (nil? b) a b))
-                             repl-opts options)))]
+                             repl-opts options)))
+          ;; Create the compiler env up front and hand it to the repl loop so we
+          ;; always hold a reference to it, even if the setup eval errors and the
+          ;; loop's :print callback (which would otherwise capture it) never runs
+          ;; (issue #62).
+          compiler-env (or (:compiler-env options) (env/default-compiler-env opts))]
       (set! ana/*cljs-ns* 'cljs.user)
       (let [out-target (atom *out*)
             err-target (atom *err*)]
@@ -219,10 +224,13 @@
                                          (:require [cljs.repl :refer-macros [source doc find-doc
                                                                              apropos dir pst]]
                                                    [cljs.pprint]))))
-                         repl-env nil options))
+                         repl-env compiler-env options))
         (set! *cljs-out-target* out-target)
         (set! *cljs-err-target* err-target))
       ;; (clojure.pprint/pprint (:options @*cljs-compiler-env*))
+      ;; Record the compiler env unconditionally, in case the setup eval errored
+      ;; and the :print callback never set it (issue #62).
+      (set! *cljs-compiler-env* compiler-env)
       (set! *cljs-repl-env* repl-env)
       (set! *cljs-repl-options* opts)
       ;; interruptible-eval is in charge of emitting the final :ns response in this context

--- a/test/cider/piggieback_setup_error_test.clj
+++ b/test/cider/piggieback_setup_error_test.clj
@@ -1,0 +1,61 @@
+(ns cider.piggieback-setup-error-test
+  "Regression test for https://github.com/nrepl/piggieback/issues/62.
+
+  Uses a fake repl env rather than a real one (e.g. Node) so the setup error can
+  be injected without a JavaScript runtime: a real runtime left half-initialized
+  by the failed setup would simply block on the next evaluation, which is a
+  separate problem and would make this test hang."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [nrepl.core :as nrepl]
+   [nrepl.server :as server]))
+
+(require 'cider.piggieback 'cljs.repl)
+
+;; A repl env that pretends every JavaScript evaluation succeeds, so the test
+;; never depends on (or blocks on) an actual JS runtime.
+(defrecord FakeReplEnv []
+  cljs.repl/IJavaScriptEnv
+  (-setup [_ _] nil)
+  (-evaluate [_ _ _ _] {:status :success :value "42"})
+  (-load [_ _ _] nil)
+  (-tear-down [_] nil))
+
+;; The initial require references a bogus namespace, so the REPL's setup eval
+;; errors out while the env itself is left perfectly usable.
+;; A dedicated output dir keeps this test's ClojureScript compilation from
+;; clobbering the default "out" dir shared with the Node-based test suite.
+(def ^:private start-code
+  (nrepl/code
+   (cider.piggieback/cljs-repl
+    (cider.piggieback-setup-error-test/->FakeReplEnv)
+    :output-dir "target/piggieback-setup-error-out"
+    :repl-requires '[[totally.bogus.does-not-exist]])))
+
+;; Before the fix, a setup error left *cljs-compiler-env* unset, so every
+;; subsequent evaluation blew up (NPE in cljs.analyzer/get-namespace) or
+;; recompiled cljs.core from scratch.
+(deftest evaluation-works-after-setup-error
+  (with-open [^nrepl.server.Server server
+              (server/start-server
+               :bind "127.0.0.1"
+               :handler (server/default-handler #'cider.piggieback/wrap-cljs-repl))]
+    (let [port (.getLocalPort ^java.net.ServerSocket (:server-socket server))
+          conn (nrepl/connect :port port)
+          session (nrepl/client-session (nrepl/client conn Long/MAX_VALUE))]
+      (try
+        (let [start (nrepl/combine-responses
+                     (nrepl/message session {:op "eval" :code start-code}))]
+          (testing "the setup really does error (otherwise the test proves nothing)"
+            (is (some? (:err start)))))
+        (testing "evaluation still works after the setup error"
+          ;; Without the fix this throws an NPE in cljs.analyzer/get-namespace
+          ;; (no compiler env), yielding an eval-error and no value.
+          (let [resp (nrepl/combine-responses
+                      (nrepl/message session {:op "eval" :code "(+ 1 1)"}))]
+            (testing (pr-str resp)
+              (is (= ["42"] (:value resp)))
+              (is (not (contains? (:status resp) "eval-error"))))))
+        (finally
+          (dorun (nrepl/message session {:op "eval" :code ":cljs/quit"}))
+          (.close ^java.io.Closeable conn))))))


### PR DESCRIPTION
If a ClojureScript REPL's initial setup eval errors out (say a bad `:repl-requires`, or any compile error during startup), piggieback was left with a `nil` compiler env: `cljs.repl/repl*` only stashes the compiler env via its `:print` callback, and that callback never runs when the setup eval throws. After that, every evaluation NPE'd in `cljs.analyzer/get-namespace` (or re-bootstrapped `cljs.core` from scratch).

This creates the compiler env up front, hands it to the repl loop, and records it unconditionally, so a setup error no longer wedges the session.

The regression test injects the failure with a tiny fake repl env, so it reproduces the exact NPE with no JavaScript runtime (and doesn't hang the way a half-initialized real runtime would). Fixes #62.