### PR TITLE
Fix printing of unknown tagged literals

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+* [#120](https://github.com/nrepl/piggieback/issues/120): Fix printing of unknown tagged literals (a space was missing after the tag and string data lost its quotes).
 * [#62](https://github.com/nrepl/piggieback/issues/62): Keep evaluation working after a REPL setup error by always recording the compiler env.
 * [#111](https://github.com/nrepl/piggieback/issues/111): Fix ClojureScript output being tagged with the REPL-starting message's id and vanishing after reconnecting to a session.
 

--- a/src/cider/piggieback_impl.clj
+++ b/src/cider/piggieback_impl.clj
@@ -99,7 +99,13 @@
 
 (defmethod print-method UnknownTaggedLiteral
   [^UnknownTaggedLiteral this ^java.io.Writer w]
-  (.write w (str "#" (.tag this) (.data this))))
+  ;; Recurse through print-method (rather than str) so the data round-trips
+  ;; correctly: strings keep their quotes, nested values are printed readably,
+  ;; and the tag and data are separated by a space (issue #120).
+  (.write w "#")
+  (print-method (.tag this) w)
+  (.write w " ")
+  (print-method (.data this) w))
 
 (defn- generate-delegating-repl-env [repl-env]
   (let [repl-env-class (class repl-env)

--- a/test/cider/piggieback_printing_test.clj
+++ b/test/cider/piggieback_printing_test.clj
@@ -1,0 +1,24 @@
+(ns cider.piggieback-printing-test
+  "Unit tests for how piggieback prints ClojureScript evaluation results that the
+  Clojure reader can't read back directly. These need no JavaScript runtime."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [clojure.tools.reader.edn :as edn]))
+
+(require 'cider.piggieback)
+
+(defn- read-as-unknown
+  "Read `s` the way `do-eval` reads a ClojureScript result, i.e. with unknown
+  tagged literals turned into `UnknownTaggedLiteral`."
+  [s]
+  (edn/read-string {:default (resolve 'cider.piggieback/->UnknownTaggedLiteral)} s))
+
+;; Regression test for https://github.com/nrepl/piggieback/issues/120
+(deftest unknown-tagged-literal-round-trips
+  (testing "string data keeps its quotes and is separated from the tag"
+    (is (= "#time/time \"10:11:12\"" (pr-str (read-as-unknown "#time/time \"10:11:12\"")))))
+  (testing "collection and map data are printed readably"
+    (is (= "#foo/bar [1 2 3]" (pr-str (read-as-unknown "#foo/bar [1 2 3]"))))
+    (is (= "#my/thing {:a 1}" (pr-str (read-as-unknown "#my/thing {:a 1}")))))
+  (testing "nested unknown tagged literals round-trip too"
+    (is (= "#a/x [#b/y \"z\"]" (pr-str (read-as-unknown "#a/x [#b/y \"z\"]"))))))


### PR DESCRIPTION
When a ClojureScript result contains a tagged literal the Clojure reader doesn't know, piggieback wraps it in an `UnknownTaggedLiteral` and prints it back out. The `print-method` built the string with `str`, which dropped the space after the tag and stripped the quotes off string data, so `#time/time "10:11:12"` came back as `#time/time10:11:12` - no longer readable.

Recursing through `print-method` for the tag and data fixes the spacing and preserves quoting (and handles nested values), so results round-trip. Comes with node-free unit tests. Fixes #120.