### PR TITLE
Fail clearly when cljs-repl runs outside a session

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+* [#124](https://github.com/nrepl/piggieback/issues/124): Throw a clear error when `cljs-repl` is invoked outside of an nREPL session (e.g. from Leiningen's `:repl-options :init`) instead of a cryptic "Can't change/establish root binding".
 * [#120](https://github.com/nrepl/piggieback/issues/120): Fix printing of unknown tagged literals (a space was missing after the tag and string data lost its quotes).
 * [#62](https://github.com/nrepl/piggieback/issues/62): Keep evaluation working after a REPL setup error by always recording the compiler env.
 * [#111](https://github.com/nrepl/piggieback/issues/111): Fix ClojureScript output being tagged with the REPL-starting message's id and vanishing after reconnecting to a session.

--- a/src/cider/piggieback_impl.clj
+++ b/src/cider/piggieback_impl.clj
@@ -193,6 +193,20 @@
   "Starts a ClojureScript REPL over top an nREPL session.  Accepts
    all options usually accepted by e.g. cljs.repl/repl."
   [repl-env & {:as options}]
+  ;; cljs-repl stores its state with `set!` on dynamic vars that the nREPL
+  ;; session middleware establishes per message. Called outside of a session -
+  ;; e.g. from Leiningen's :repl-options :init, which runs at startup before any
+  ;; session exists - those vars have no thread binding and `set!` fails with a
+  ;; cryptic "Can't change/establish root binding" error (issue #124). Fail fast
+  ;; with an actionable message instead.
+  (when-not (thread-bound? #'*cljs-repl-env*)
+    (throw (ex-info
+            (str "cider.piggieback/cljs-repl must be invoked from within an nREPL "
+                 "session, e.g. by evaluating it at a REPL connected to an nREPL "
+                 "server that has the wrap-cljs-repl middleware. It cannot be "
+                 "started from a plain Clojure REPL or from Leiningen's "
+                 ":repl-options :init, both of which run outside of any session.")
+            {:repl-env repl-env})))
   (try
     (let [repl-opts (cljs.repl/-repl-options repl-env)
           repl-env (delegating-repl-env repl-env)

--- a/test/cider/piggieback_no_session_test.clj
+++ b/test/cider/piggieback_no_session_test.clj
@@ -1,0 +1,23 @@
+(ns cider.piggieback-no-session-test
+  "Regression test for https://github.com/nrepl/piggieback/issues/124: calling
+  cljs-repl outside of an nREPL session should fail with a clear message rather
+  than a cryptic \"Can't change/establish root binding\" error."
+  (:require
+   [clojure.test :refer [deftest is]]))
+
+(require 'cider.piggieback 'cljs.repl)
+
+(defn- fake-repl-env []
+  (reify cljs.repl/IJavaScriptEnv
+    (-setup [_ _] nil)
+    (-evaluate [_ _ _ _] {:status :success :value "nil"})
+    (-load [_ _ _] nil)
+    (-tear-down [_] nil)))
+
+(deftest cljs-repl-outside-session-fails-clearly
+  ;; This test thread is not an nREPL session, so the piggieback vars are not
+  ;; thread-bound - the same situation as a Leiningen :init.
+  (is (thrown-with-msg?
+       clojure.lang.ExceptionInfo
+       #"must be invoked from within an nREPL session"
+       (cider.piggieback/cljs-repl (fake-repl-env)))))


### PR DESCRIPTION
`cljs-repl` stashes its state with `set!` on dynamic vars that the nREPL session middleware binds per message. When it's invoked outside a session - the classic case being Leiningen's `:repl-options :init`, which runs at JVM startup before any session exists - those vars have no thread binding and `set!` blows up with a cryptic `Can't change/establish root binding of: *cljs-repl-env*`.

There's no session there to hold the REPL's state, so this genuinely can't work from `:init`; the fix is to detect the situation and throw an actionable error pointing at the supported approach (connect to an nREPL server with the middleware and evaluate `cljs-repl` there) instead of leaking the JVM-level error.

Node-free regression test included. Fixes #124.