### PR TITLE
Add regression test for custom data readers

### DIFF
--- a/test/cider/piggieback_data_readers_test.clj
+++ b/test/cider/piggieback_data_readers_test.clj
@@ -1,0 +1,18 @@
+(ns cider.piggieback-data-readers-test
+  "Regression test for https://github.com/nrepl/piggieback/issues/128: custom
+  data readers declared in data_readers.cljc should be honored when reading
+  ClojureScript forms at the REPL. Needs no JavaScript runtime."
+  (:require
+   [clojure.test :refer [deftest is]]
+   [cljs.analyzer :as ana]
+   [cljs.env :as env]))
+
+(require 'cider.piggieback 'cider.test-data-readers)
+
+(deftest custom-data-readers-are-honored
+  ;; read-cljs-string needs a compiler env and a current CLJS ns, just like it
+  ;; has during real evaluation.
+  (env/with-compiler-env (env/default-compiler-env)
+    (binding [ana/*cljs-ns* 'cljs.user]
+      (is (= [:cider.test-data-readers/lstr "gaol@en-uk"]
+             (cider.piggieback/read-cljs-string "#piggieback.test/lstr \"gaol@en-uk\""))))))

--- a/test/cider/test_data_readers.clj
+++ b/test/cider/test_data_readers.clj
@@ -1,0 +1,6 @@
+(ns cider.test-data-readers
+  "A trivial data reader used by the #128 regression test. Kept dependency-free
+  because it is required early, while Clojure loads data_readers.cljc.")
+
+(defn read-lstr [s]
+  [::lstr s])

--- a/test/data_readers.cljc
+++ b/test/data_readers.cljc
@@ -1,0 +1,1 @@
+{piggieback.test/lstr cider.test-data-readers/read-lstr}


### PR DESCRIPTION
Investigating #128: custom data readers declared in `data_readers.cljc` already resolve when piggieback reads ClojureScript forms. All supported ClojureScript versions (1.10, 1.11, 1.12) build `cljs.tagged-literals/*cljs-data-readers*` by merging Clojure's `*data-readers*`, so `read-cljs-string` already picks them up - the change proposed in the issue is a no-op on the current stack.

This locks the behavior in with a node-free regression test (a `data_readers.cljc`, a tiny reader-fn ns, and the test) so it can't silently regress.

One caveat for #128: the reporter's specific error (`LangStr ... not a valid ClojureScript constant`) is a library-side issue - that data reader returns a JVM object that isn't a valid CLJS constant, which piggieback can't change. Refs #128.
