### PR TITLE
Tidy up gitignore and README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/out
 /lib
 /classes
 /checkouts

--- a/README.md
+++ b/README.md
@@ -57,12 +57,8 @@ The `:repl-options` bit causes `lein repl` to automagically mix the Piggieback
 nREPL middleware into its default stack.
 
 _If you're using Leiningen directly, or as the basis for the REPLs in your local
-development environment (e.g. CIDER, fireplace, counterclockwise, etc), you're
+development environment (e.g. CIDER, fireplace, etc), you're
 done._ [Skip to starting a ClojureScript REPL](#usage).
-
-### Boot
-
-Contributions welcome!
 
 ### Clojure CLI (aka `tools.deps`)
 


### PR DESCRIPTION
Small housekeeping:

- Ignore the `out/` directory (the Node test REPL compiles ClojureScript there by default, so it's a stray `git add` away from being committed)
- Drop the empty "Boot" section (Boot is unmaintained) and a leftover Counterclockwise reference in the Leiningen instructions