### PR TITLE
Bump cljfmt and Clojure to latest

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -11,14 +11,14 @@
  {;; Latest stable versions, used for `clj -M:dev` and as the default test deps.
   :dev
   {:extra-paths ["env/repl"]
-   :extra-deps {org.clojure/clojure {:mvn/version "1.12.0"}
+   :extra-deps {org.clojure/clojure {:mvn/version "1.12.5"}
                 org.clojure/clojurescript {:mvn/version "1.12.145"}
                 nrepl/nrepl {:mvn/version "1.7.0"}}}
 
   ;; Run the test suite: `clj -X:test`
   :test
   {:extra-paths ["test" "env/test"]
-   :extra-deps {org.clojure/clojure {:mvn/version "1.12.0"}
+   :extra-deps {org.clojure/clojure {:mvn/version "1.12.5"}
                 org.clojure/clojurescript {:mvn/version "1.12.145"}
                 nrepl/nrepl {:mvn/version "1.7.0"}
                 io.github.cognitect-labs/test-runner

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
                                     :password :env/clojars_password
                                     :sign-releases false}]]
 
-  :profiles {:provided {:dependencies [[org.clojure/clojure "1.12.0"]
+  :profiles {:provided {:dependencies [[org.clojure/clojure "1.12.5"]
                                        [org.clojure/clojurescript "1.12.145"]
                                        [nrepl/nrepl "1.0.0"]]}
 
@@ -25,7 +25,7 @@
              :1.11 {:dependencies [[org.clojure/clojure "1.11.4"]
                                    [org.clojure/clojurescript "1.11.132"]]}
 
-             :1.12 {:dependencies [[org.clojure/clojure "1.12.0"]
+             :1.12 {:dependencies [[org.clojure/clojure "1.12.5"]
                                    [org.clojure/clojurescript "1.12.145"]]}
 
              :nrepl-1.0 {:dependencies [[nrepl/nrepl "1.0.0"]]}
@@ -40,7 +40,7 @@
                            {:source-paths ["env/repl"]
                             :repl-options {:nrepl-middleware [cider.piggieback/wrap-cljs-repl]}}]
 
-             :cljfmt {:plugins [[lein-cljfmt "0.9.2"]]}
+             :cljfmt {:plugins [[dev.weavejester/lein-cljfmt "0.16.4"]]}
 
              :eastwood {:plugins  [[jonase/eastwood "1.4.3"]]
                         :eastwood {:config-files ["eastwood.clj"]


### PR DESCRIPTION
Follow-up dep audit. Two updates:

- cljfmt: the `lein-cljfmt` coordinate was abandoned at 0.9.2; cljfmt now lives under `dev.weavejester/lein-cljfmt`, so switch to that and jump to 0.16.4. Formatting still checks clean.
- Clojure: 1.12.0 -> 1.12.5 (provided/1.12 profiles and deps.edn).

ClojureScript (1.12.145), Eastwood (1.4.3) and nREPL (1.7.0) are already current.