### PR TITLE
Add architecture and roadmap docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,11 @@ was dropped from ClojureScript in 1.10.741.*
 This section documents some of the main design decisions in Piggieback
 and the differences between similar functionality in nREPL and Piggieback.
 
+For a deeper, diagram-driven tour of the internals (how nREPL, Piggieback and
+the ClojureScript runtime interact, the evaluation lifecycle, and the known
+structural gaps) see [docs/architecture.md](docs/architecture.md). Where
+Piggieback is headed next is tracked in [docs/roadmap.md](docs/roadmap.md).
+
 Perhaps the most important thing to remember is that Piggieback is written in
 Clojure and runs on Clojure. It drives ClojureScript evaluation by using
 ClojureScript's Clojure API (`cljs.repl/IJavaScriptEnv`).  This allows you to

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,315 @@
+# Piggieback Architecture
+
+This document explains how Piggieback works internally: how it sits inside an
+nREPL server, how it routes ClojureScript evaluation, and the mechanisms it uses
+to bridge two runtimes that were never designed to meet. It complements the
+shorter "Design" section in the [README](../README.md), which covers the
+user-facing behaviour and rationale.
+
+If you are here to plan changes rather than understand the current code, see the
+[roadmap](roadmap.md).
+
+## Purpose and scope
+
+Piggieback is a single, focused thing: an nREPL middleware that lets a normal
+nREPL server evaluate ClojureScript in the official `cljs.repl` REPL
+environments (node, browser, graaljs, ...) without a separate build tool. It is
+written in Clojure and runs on the JVM. It drives ClojureScript evaluation
+through ClojureScript's Clojure-facing compiler API, primarily the
+`cljs.repl/IJavaScriptEnv` protocol.
+
+What it is *not*: a build tool, a hot-reload system, or a replacement for
+shadow-cljs / figwheel-main (both of which ship their own nREPL story and do not
+use Piggieback). The clearest way to think about Piggieback today is as the thin,
+correct adapter between nREPL and stock `cljs.repl` environments, plus CIDER's
+built-in default for "just give me a cljs REPL."
+
+## Mental model: one server, two languages
+
+A single nREPL server can host both Clojure and ClojureScript evaluation at the
+same time, on a per-session basis. Whether a given `eval` runs as Clojure or as
+ClojureScript is decided entirely by session state, not by anything the client
+puts in the message. A client "enters" ClojureScript by evaluating
+`(cider.piggieback/cljs-repl <repl-env>)` in a session; from then on, that
+session's `eval` and `load-file` ops are handled by Piggieback until the client
+sends `:cljs/quit`.
+
+```mermaid
+flowchart TB
+    client["nREPL client<br/>(CIDER, Calva, ...)"]
+
+    subgraph jvm["JVM - nREPL server"]
+        direction TB
+        session["Transport + Session<br/>(holds the dynamic-var state)"]
+
+        subgraph stack["Middleware stack"]
+            direction TB
+            wprint["wrap-print"]
+            piggie["wrap-cljs-repl"]
+            ieval["interruptible-eval"]
+        end
+
+        subgraph pb["Piggieback (Clojure)"]
+            direction TB
+            route["evaluate / load-file"]
+            doeval["do-eval"]
+            core["read-cljs-string + eval-cljs"]
+            deleg["Delegating repl-env<br/>(swallows -tear-down)"]
+        end
+
+        subgraph cljs["ClojureScript compiler - Clojure API"]
+            direction TB
+            ef["cljs.repl/evaluate-form"]
+            env["IJavaScriptEnv impl<br/>(node / browser / ...)"]
+        end
+    end
+
+    runtime["JS runtime<br/>(node subprocess / browser)"]
+
+    client <--> session
+    session --> wprint --> piggie
+    piggie -->|"eval/load-file when<br/>session has *cljs-repl-env*"| route
+    piggie -.->|"everything else"| ieval
+    route --> doeval --> core --> ef
+    ef --> deleg --> env
+    env <-->|"-evaluate + async output pump"| runtime
+```
+
+The key seam is `wrap-cljs-repl`: for every message it inspects the session. If
+the session has an active `*cljs-repl-env*` and the op is `eval` or `load-file`,
+it hijacks the message and runs Piggieback's ClojureScript evaluation. Otherwise
+it passes the message straight through to the rest of the stack (ordinary
+Clojure handling).
+
+## Core concepts
+
+### Session-based dispatch
+
+Piggieback operates at the nREPL *session* level. Clients do not pass an
+`:env :cljs` parameter or call a dedicated op; they just keep using `eval` with a
+session that has a ClojureScript REPL active. This is what makes a mixed
+Clojure/ClojureScript server transparent to tooling. The price is that
+ClojureScript-ness is implicit: nothing in the protocol (for example the
+`describe` response) currently advertises that a session is in ClojureScript
+mode, so tools infer it out of band. (See roadmap item M3.)
+
+### Dynamic vars as session state
+
+ClojureScript REPL state lives in a handful of dynamic vars, all private to the
+`cider.piggieback` namespace:
+
+| Var | Holds |
+| --- | --- |
+| `*cljs-repl-env*` | the active (delegating) repl-env; also the "are we in cljs?" flag |
+| `*cljs-compiler-env*` | the ClojureScript compiler environment (analyzer/compiler state) |
+| `*cljs-repl-options*` | the merged repl options |
+| `*cljs-warnings*` / `*cljs-warning-handlers*` | analyzer warning configuration |
+| `*original-clj-ns*` | the Clojure namespace to restore on `:cljs/quit` |
+| `*cljs-out-target*` / `*cljs-err-target*` | atoms repointed at the current message's output (see Output forwarding) |
+
+These are not root-bound. nREPL's session middleware establishes per-message
+thread bindings for the vars stored in the session atom, and merges any `set!`
+changes back into the session atom when the message completes. So the flow is:
+`cljs-repl` does `set!` on these vars (which works because the bindings exist for
+the duration of the message), and `wrap-cljs-repl` seeds the session atom with
+them up front so the bindings are present. This is also why `cljs-repl` fails
+fast if it is called outside a session: with no thread binding, `set!` would
+throw a cryptic root-binding error (issue #124).
+
+### Optional ClojureScript
+
+Piggieback has no hard dependency on ClojureScript. The main namespace
+(`cider.piggieback`) uses a small `if-ns` macro to conditionally `(load ...)`
+one of two files at compile time: the real implementation
+(`piggieback_impl.clj`) when `cljs.repl` is on the classpath, or a no-op shim
+(`piggieback_shim.clj`) when it is not. Both files `(in-ns 'cider.piggieback)`
+and define the same vars, so consumers can load Piggieback unconditionally. This
+predates `requiring-resolve` and is a candidate for simplification (roadmap item
+S1).
+
+## Lifecycle walkthroughs
+
+### Starting a ClojureScript REPL
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as nREPL client
+    participant W as wrap-cljs-repl
+    participant IE as interruptible-eval
+    participant PB as cljs-repl
+    participant R as cljs.repl/repl*
+    participant E as repl-env (node)
+    participant JS as JS runtime
+
+    C->>W: eval "(cljs-repl (node/repl-env))"
+    Note over W: session has no *cljs-repl-env*<br/>so this is a normal Clojure eval
+    W->>IE: pass through
+    IE->>PB: invoke cljs-repl
+    PB->>PB: wrap repl-env in a delegating env,<br/>build default-compiler-env up front
+    PB->>R: run-cljs-repl (ns-require form + " :cljs/quit")
+    R->>E: -setup
+    E->>JS: launch runtime
+    R-->>PB: :print callback records compiler-env
+    PB->>PB: set! dynamic vars, switch *ns* to cljs.user
+    PB-->>C: "To quit, type: :cljs/quit"
+```
+
+Setup is the one place Piggieback drives `cljs.repl/repl*` (the full REPL loop)
+rather than evaluating forms itself. It feeds the loop a single namespace-require
+form plus `:cljs/quit`, with no-op `:prompt` / `:need-prompt` / `:init`
+callbacks, and reaches the compiler env back out through the `:print` callback.
+The compiler env is also created up front and captured unconditionally, so that
+evaluation still works even if the setup eval errors before `:print` runs (issue
+#62).
+
+### Evaluating a form
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as nREPL client
+    participant W as wrap-cljs-repl
+    participant EV as evaluate / do-eval
+    participant RD as read-cljs-string
+    participant EF as cljs.repl/evaluate-form
+    participant E as repl-env
+    participant JS as JS runtime
+
+    C->>W: eval "(+ 1 1)" (Piggieback session)
+    Note over W: session has *cljs-repl-env*
+    W->>EV: route to evaluate, enqueue on the session executor
+    EV->>EV: with-bindings (compiler-env, repl-env, warnings),<br/>repoint forwarding writers at this msg's *out*/*err*
+    EV->>RD: read form (cljs data readers + ns alias map)
+    RD-->>EV: form
+    EV->>EF: eval-cljs (wrapped for *1/*2/*3 and pretty-printing)
+    EF->>E: -evaluate
+    E->>JS: run compiled JS
+    JS-->>E: result (printed string)
+    Note over E,JS: a separate output-pump thread writes<br/>stdout/stderr asynchronously, via the<br/>forwarding writer, to this message's *out*
+    E-->>EF: result
+    EF-->>EV: result
+    EV->>EV: track current cljs ns back into the session
+    EV-->>C: :value, :ns
+```
+
+Ongoing evaluation does *not* go through `repl*`. It calls
+`cljs.repl/evaluate-form` directly, reusing the compiler env and repl-env stored
+in the session. The result comes back as a printed string, which Piggieback
+re-reads with an EDN reader (using `UnknownTaggedLiteral` as the default tag
+handler so unknown tagged literals round-trip) before sending it as `:value`.
+
+Note the two distinct evaluation paths (setup via `repl*`, steady-state via
+`evaluate-form`). That split is the source of much of Piggieback's incidental
+complexity and is the target of the largest planned refactor (roadmap item B1).
+
+### Session REPL state and the teardown gap
+
+```mermaid
+stateDiagram-v2
+    [*] --> Clojure: session created
+    Clojure --> ClojureScript: cljs-repl invoked (sets *cljs-repl-env*)
+    ClojureScript --> ClojureScript: eval / load-file routed to Piggieback
+    ClojureScript --> Clojure: ":cljs/quit" (-tear-down, vars reset)
+    Clojure --> [*]: session closed
+
+    note right of ClojureScript
+      Gap: if a session is closed
+      (or the client disconnects)
+      while here, -tear-down is
+      never called and the JS
+      runtime leaks. Roadmap C1.
+    end note
+```
+
+Teardown currently happens only on an explicit `:cljs/quit`. There is no hook on
+session close or expiry, so a dropped connection leaves the node subprocess or
+browser connection running. This is a real correctness gap, tracked as roadmap
+item C1.
+
+## Implementation mechanisms
+
+These are the non-obvious pieces that make the bridge work.
+
+### Delegating repl-env
+
+`cljs.repl/repl*` calls `-tear-down` on the repl-env when its loop exits, which
+(because setup appends `:cljs/quit`) would tear the env down immediately after
+setup. To prevent that, Piggieback wraps the real repl-env in a generated
+"delegating" type whose `-tear-down` is a no-op and which forwards every other
+`IJavaScriptEnv` method (and map-like access) to the wrapped env. The wrapper is
+currently generated per repl-env class at runtime via `eval`. Removing the
+`repl*` driving would remove the need for this wrapper entirely (roadmap B1).
+
+### Output forwarding (issue #111)
+
+ClojureScript repl envs such as the node env run an asynchronous output pump on
+their own thread and capture `*out*` once, at setup time, via `bound-fn`. Under
+nREPL, `*out*` is rebound per message, so a captured `*out*` would keep sending
+all later output to the message that *started* the REPL (and that output would
+vanish once that connection closed). Piggieback hands the env a
+`forwarding-writer`: a `java.io.Writer` that delegates to whatever writer is
+currently held in an atom (`*cljs-out-target*` / `*cljs-err-target*`). On each
+evaluation, `do-eval` repoints those atoms at the current message's output. The
+writer flushes rather than closes on `close`, because the underlying per-message
+writers are owned by nREPL.
+
+### Namespace tracking
+
+The current ClojureScript namespace (`cljs.analyzer/*cljs-ns*`) is stored in the
+session atom and updated after each eval, so that `in-ns` and namespace switches
+persist across messages and are reported back as `:ns`. The reader is configured
+with the analyzer's `resolve-symbol`, the cljs data readers, and an alias map
+reconstructed from the current namespace's `:requires` / `:require-macros`, so
+that alias-qualified keywords and reader conditionals read correctly.
+
+### Result wrapping: `*1` `*2` `*3` `*e` and pretty-printing
+
+Before evaluation, the form is wrapped (`pprint-repl-wrap-fn`) so that the result
+rolls the REPL history vars (`*1`/`*2`/`*3`), captures exceptions into `*e`, and
+optionally pretty-prints. The choice between plain printing and pretty-printing
+currently keys off the name of the requested print function. ns/require/import
+forms are passed through unwrapped.
+
+### Special forms
+
+ClojureScript REPL special functions (`cljs.repl/default-special-fns`, merged
+with any from the repl options) are dispatched directly rather than evaluated, so
+things like `load-file`, `in-ns`, and `require` behave like REPL specials.
+
+## Structural constraints and known gaps
+
+These are limitations that are either upstream or architectural; each maps to a
+roadmap item.
+
+- **One node REPL per JVM.** `cljs.repl.node` keys its results/output state by
+  thread name, which collapses nREPL's worker threads together. Two node REPLs in
+  one JVM clobber each other. Upstream; roadmap U1 (issues #105, #88).
+- **`*out*` capture.** The forwarding-writer machinery exists only to compensate
+  for the node env capturing `*out*` at setup. The clean fix is upstream; roadmap
+  U2.
+- **`load-file` loads from disk.** Piggieback's `load-file` re-reads the file
+  from `file-path` on disk rather than evaluating the source sent in the message,
+  which diverges from Clojure nREPL semantics (loading an unsaved buffer loads the
+  saved version). Roadmap C2.
+- **No session-close teardown.** See the state diagram above; roadmap C1.
+- **Multi-form evaluation.** Only the first form of a multi-form string is
+  evaluated, because steady-state eval does not spin a fresh `cljs.repl` per
+  message (see the README Design section).
+- **Interrupt.** A long-running JS eval cannot be cancelled cleanly. This is
+  largely inherent to single-threaded JS runtimes but is currently undocumented.
+
+## Compatibility surface
+
+Piggieback supports a range of nREPL versions (1.0 through current). The
+differences are handled by runtime feature detection (for example resolving
+`interruptible-eval/evaluator` to decide how to bind per-message state, and
+resolving `replying-PrintWriter` for print middleware). These checks are
+currently spread across the implementation; centralizing them is roadmap item M1.
+
+Piggieback also couples tightly to ClojureScript compiler internals
+(`cljs.analyzer`, `cljs.env`, `cljs.closure`, `cljs.tagged-literals`, and the
+non-public parts of `cljs.repl`). This is largely unavoidable given there is no
+public "evaluate a cljs form in this env and hand me the result" API, but it is
+fragile, and isolating it behind one thin, version-guarded namespace is roadmap
+item M2 (and a prerequisite for B1).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,196 @@
+# Piggieback Roadmap
+
+A plan for evolving Piggieback's internals. This is a direction, not a contract:
+items can be reordered or dropped as we learn more. For how the current code
+works, see the [architecture document](architecture.md).
+
+## Guiding principle
+
+Piggieback's job is narrow and worth doing well: be the thin, correct adapter
+between nREPL and the official `cljs.repl` environments, and CIDER's built-in
+default cljs REPL. shadow-cljs and figwheel-main own the heavyweight build-tool
+space and bring their own nREPL integration, so Piggieback should not chase
+features they already cover (hot reload, asset serving, file watching). Almost
+every item below is "make the adapter simpler or more correct," not "add
+surface."
+
+## Sequencing rationale
+
+The instinct to start small is right, and for a stronger reason than low risk:
+two of the small items are the *seams* that make the one scary refactor safe.
+
+- **M1** (centralize nREPL-version compatibility) and **M2** (isolate the
+  ClojureScript-internals coupling into one thin eval core) carve out clean
+  boundaries. Once they exist, **B1** (own evaluation, drop the `repl*` driving)
+  is a change behind a known interface instead of open-heart surgery.
+- **C1** and **C2** are standalone correctness wins with no dependency on
+  anything else, so they ride along early and ship value immediately.
+
+So the order is: seams and correctness first, structural simplification next, the
+core refactor once the seams are in place, and upstream work filed early because
+it has the longest lead time.
+
+## Status
+
+- Done: tooling modernization. CI matrix (CircleCI, JDK 8-25, Clojure 1.10-1.12,
+  nREPL 1.0-1.7), `deps.edn` alongside Leiningen, clj-kondo added, cljfmt and
+  Eastwood on current versions, dependencies refreshed.
+- Done: the Phase 2 correctness bugs from the 0.6.2 release (#62, #111, #120,
+  #124).
+
+## Phase 1 - Seams and small modernizations
+
+Low risk, high clarity, and partly preparatory for Phase 4.
+
+### M1 - Centralize cross-nREPL-version compatibility
+
+Today, support for the supported nREPL range is handled by `resolve`-based
+feature detection scattered through the implementation (`nrepl-1-3+?`,
+`replying-PrintWriter` lookup, the `enqueue` double-binding dance). Pull these
+into one small compatibility namespace with named, documented predicates and
+shims.
+
+- Why: one place to reason about version differences; less noise in the eval path.
+- Risk: low. Pure refactor, behaviour-preserving, fully covered by the nREPL
+  matrix in CI.
+
+### M2 - Isolate the ClojureScript-internals coupling
+
+Gather the direct reaches into `cljs.analyzer`, `cljs.env`, `cljs.closure`,
+`cljs.tagged-literals`, and the non-public parts of `cljs.repl` into a single,
+thin, version-guarded "cljs eval core" namespace. The handler code should talk to
+that core, not to compiler internals directly.
+
+- Why: this is the seam B1 needs. It also localizes the fragility, so a breaking
+  ClojureScript change touches one file.
+- Risk: low to moderate. Mechanical extraction, but it touches the hot path, so
+  lean on the existing tests and add characterization tests where thin.
+- Prerequisite for: B1.
+
+### M3 - Surface ClojureScript state in `describe`
+
+Advertise Piggieback in the `describe` response and expose whether a session is
+currently in ClojureScript mode (and ideally which repl-env). Optionally echo
+cljs-ness on eval responses.
+
+- Why: tooling currently infers ClojureScript mode out of band. A protocol-level
+  signal lets clients stop guessing.
+- Risk: low. Additive.
+
+### M4 - Robust print-mode detection
+
+Replace the current string-name matching against specific print functions with a
+more robust signal for choosing plain vs pretty printing.
+
+- Why: the present check breaks the moment a different pretty-printer is used.
+- Risk: low.
+
+### M5 - Document the interrupt limitation
+
+A long-running JS eval cannot be cancelled cleanly. Document this clearly rather
+than leaving it implicit, and decide whether any best-effort behaviour is worth
+offering.
+
+- Why: sets correct expectations; cheap.
+- Risk: none (documentation).
+
+## Phase 2 - Standalone correctness wins
+
+Independent of everything else; ship as soon as ready.
+
+### C1 - Tear down on session close
+
+Register cleanup on session close / expiry so the active repl-env's `-tear-down`
+runs even when the client never sends `:cljs/quit` (dropped connection, editor
+killed, client exit). Today the node subprocess or browser connection leaks.
+
+- Why: a real resource leak that bites anyone who closes an editor without
+  quitting the cljs REPL first.
+- Risk: low to moderate. Needs care around nREPL session lifecycle hooks and not
+  double-tearing-down on a normal quit. Add a regression test.
+
+### C2 - `load-file` evaluates the sent content
+
+Make `load-file` compile the source provided in the message against the right
+namespace and path, rather than re-reading the file from disk. This matches
+Clojure nREPL semantics ("load buffer" should load what is in the buffer).
+
+- Why: loading an unsaved buffer currently loads the last-saved version, silently.
+- Risk: moderate. Touches the `load-file` path and the path/namespace handling;
+  needs tests for both saved and unsaved content.
+
+## Phase 3 - Structural simplification
+
+### S1 - Single namespace via `requiring-resolve`
+
+Collapse the three-file `if-ns` + `(load ...)` + `(in-ns)` structure into one
+namespace that resolves the ClojureScript machinery lazily at first use and
+returns a no-op middleware when ClojureScript is absent.
+
+- Why: removes the `redefined-var` / `unresolved-symbol` friction we currently
+  paper over in clj-kondo config, and reads far more honestly. Clojure 1.10
+  (our floor) has `requiring-resolve`.
+- Risk: moderate. The no-ClojureScript path must stay a genuine no-op; test both
+  with and without ClojureScript on the classpath.
+
+## Phase 4 - The core refactor
+
+### B1 - Own evaluation; remove the `repl*` driving and the codegen delegator
+
+Stop driving `cljs.repl/repl*` for setup. Instead: run `-setup` once, establish
+the analyzer/compiler bindings explicitly, run the initial requires as an ordinary
+`evaluate-form`, and use one uniform evaluation path for everything. This
+collapses the two evaluation paths into one, removes the `:print`-callback
+side-channel for reaching compiler state, and eliminates the runtime-generated
+delegating repl-env (which exists only to swallow the `-tear-down` that `repl*`
+would otherwise trigger after setup).
+
+- Why: this split is the root cause of most of Piggieback's historical bugs
+  (compiler-env capture, output routing, ns tracking). Unifying the path is what
+  stops the next decade of the same class of bug.
+- Risk: high. This is the riskiest change in the plan. Do it on a branch, behind
+  the full CI matrix, after M1 and M2 have established clean seams.
+- Depends on: M1, M2.
+
+## Phase 5 - Upstream work
+
+File these early; they have the longest lead time and help the wider ecosystem
+(shadow-cljs and figwheel-main hit the same walls).
+
+### U1 - `cljs.repl.node` per-thread state (issues #105, #88)
+
+`cljs.repl.node` keys its results/output state by thread name, which collapses
+nREPL's worker threads and prevents two node REPLs in one JVM. Propose keying by
+env identity instead. Until/unless it lands upstream, a vendored corrected node
+env is a fallback.
+
+- Why: lifts the "one node REPL per JVM" ceiling, which increasingly bites (two
+  editor windows, or node plus browser at once).
+- Risk: the change itself is small; the lead time is in coordinating upstream.
+
+### U2 - node env `*out*` capture (root cause of #111)
+
+Propose letting the node env take an explicit writer / output-fn instead of
+capturing `*out*` at setup. If accepted, Piggieback's forwarding-writer
+workaround can eventually be retired.
+
+- Why: removes load-bearing cleverness in favour of a clean upstream contract.
+- Risk: long lead time; the local workaround stays until it lands.
+
+## Dependency summary
+
+```mermaid
+flowchart LR
+    M1["M1 nREPL compat seam"] --> B1["B1 own evaluation"]
+    M2["M2 cljs eval core seam"] --> B1
+    C1["C1 session-close teardown"]
+    C2["C2 load-file content"]
+    S1["S1 single-namespace rewrite"]
+    M3["M3 describe surfaces cljs"]
+    M4["M4 robust print mode"]
+    M5["M5 document interrupt"]
+    U1["U1 node per-thread state"]
+    U2["U2 node *out* capture"]
+
+    U2 -.->|"eventually retires"| FW["forwarding-writer workaround"]
+```


### PR DESCRIPTION
Adds `docs/architecture.md` and `docs/roadmap.md`, linked from the README's Design section.

The architecture doc is a diagram-driven tour of the internals: a component map of how nREPL, Piggieback and the ClojureScript runtime fit together, sequence diagrams for starting a REPL and evaluating a form, a state diagram for the session lifecycle (which also surfaces the session-close teardown gap), and write-ups of the trickier mechanisms (delegating repl-env, output forwarding, ns tracking).

The roadmap sequences the planned work seams-and-correctness-first, with the rationale that the two small "isolate the seams" items are what make the big eval-ownership refactor safe to attempt later.

Diagrams are Mermaid, so they're best reviewed rendered on the GitHub diff.