### PR TITLE
Centralize cross-nREPL-version compatibility shims

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -37,12 +37,14 @@ it has the longest lead time.
   Eastwood on current versions, dependencies refreshed.
 - Done: the Phase 2 correctness bugs from the 0.6.2 release (#62, #111, #120,
   #124).
+- Done: **M1** - cross-nREPL-version compatibility centralized into the
+  `cider.piggieback.compat` namespace.
 
 ## Phase 1 - Seams and small modernizations
 
 Low risk, high clarity, and partly preparatory for Phase 4.
 
-### M1 - Centralize cross-nREPL-version compatibility
+### M1 - Centralize cross-nREPL-version compatibility (done)
 
 Today, support for the supported nREPL range is handled by `resolve`-based
 feature detection scattered through the implementation (`nrepl-1-3+?`,

--- a/src/cider/piggieback/compat.clj
+++ b/src/cider/piggieback/compat.clj
@@ -1,0 +1,32 @@
+(ns cider.piggieback.compat
+  "Shims for the differences between the supported nREPL versions (1.0+).
+
+  Piggieback supports a range of nREPL releases whose internals differ in a few
+  places. Those differences are detected and papered over here, via runtime
+  `resolve` checks, so the rest of the codebase can stay version-agnostic."
+  ;; interruptible-eval must be loaded before the load-time `nrepl-1-3+?`
+  ;; resolve below runs, otherwise the var lookup yields nil and we'd misdetect
+  ;; 1.3+ as older.
+  (:require
+   [nrepl.middleware.interruptible-eval]))
+
+(def nrepl-1-3+?
+  "True on nREPL 1.3 or newer.
+
+  As of nREPL 1.3 the session middleware already establishes per-message thread
+  bindings for the session's dynamic vars, so Piggieback must NOT rebind them
+  from the session atom itself (doing so would clobber the values the session
+  middleware set up). On older versions Piggieback has to bind them. Detected
+  via the `evaluator` var that nREPL 1.3 introduced."
+  (some? (resolve 'nrepl.middleware.interruptible-eval/evaluator)))
+
+(defn output-bindings
+  "Return a binding map routing `*out*`/`*err*` through nREPL's print middleware
+  for `msg`, or nil when the print middleware isn't available.
+
+  Uses `replying-PrintWriter`, which streams output back to the client as it is
+  produced rather than buffering it until the evaluation completes."
+  [msg]
+  (when-let [replying-PrintWriter (resolve 'nrepl.middleware.print/replying-PrintWriter)]
+    {#'*out* (replying-PrintWriter :out msg {})
+     #'*err* (replying-PrintWriter :err msg {})}))

--- a/src/cider/piggieback_impl.clj
+++ b/src/cider/piggieback_impl.clj
@@ -11,6 +11,7 @@
  '[cljs.env :as env]
  '[cljs.analyzer :as ana]
  '[cljs.tagged-literals :as tags]
+ '[cider.piggieback.compat :as compat]
  '[nrepl.core :as nrepl]
  '[nrepl.middleware.interruptible-eval :as ieval]
  '[nrepl.misc :as misc :refer [response-for]]
@@ -329,27 +330,19 @@
                                      #'pprint-repl-wrap-fn)) form)
                            opts))
 
-(defn- output-bindings [{:keys [session] :as msg}]
-  (when-let [replying-PrintWriter (resolve 'nrepl.middleware.print/replying-PrintWriter)]
-    {#'*out* (replying-PrintWriter :out msg {})
-     #'*err* (replying-PrintWriter :err msg {})}))
-
-(def nrepl-1-3+? (some? (resolve 'ieval/evaluator)))
-
 (defn do-eval [{:keys [session transport ^String code file ns] :as msg}]
   (with-bindings (merge {#'ana/*cljs-warnings* ana/*cljs-warnings*
                          #'ana/*cljs-warning-handlers* ana/*cljs-warning-handlers*
                          #'ana/*unchecked-if* ana/*unchecked-if*
                          #'env/*compiler* (get @session #'*cljs-compiler-env*)
                          #'cljs.repl/*repl-env* (get @session #'*cljs-repl-env*)}
-                        ;; ieval/evaluator appeared in nREPL 1.3 where session
-                        ;; contents are already bound by session middleware and
-                        ;; should NOT be rebound here.
-                        (when-not nrepl-1-3+?
+                        ;; On nREPL 1.3+ the session middleware already binds the
+                        ;; session contents, so we must not rebind them here.
+                        (when-not compat/nrepl-1-3+?
                           @session)
                         (when ns
                           {#'ana/*cljs-ns* (symbol ns)})
-                        (output-bindings msg))
+                        (compat/output-bindings msg))
     ;; Repoint the repl env's output-pump thread at this message's output (#111).
     (when *cljs-out-target* (reset! *cljs-out-target* *out*))
     (when *cljs-err-target* (reset! *cljs-err-target* *err*))

--- a/test/cider/piggieback_compat_test.clj
+++ b/test/cider/piggieback_compat_test.clj
@@ -1,0 +1,25 @@
+(ns cider.piggieback-compat-test
+  (:require
+   [clojure.test :refer [deftest is]]
+   [cider.piggieback.compat :as compat]
+   [nrepl.transport :as transport]))
+
+(deftest nrepl-1-3+?-is-a-boolean
+  ;; Whatever nREPL version we're running against, the detection must resolve to
+  ;; a concrete boolean (never nil), since it gates a `when-not`.
+  (is (boolean? compat/nrepl-1-3+?)))
+
+(deftest output-bindings-routes-out-and-err
+  (let [msg {:id "1"
+             :transport (reify transport/Transport
+                          (recv [this] this)
+                          (recv [this _timeout] this)
+                          (send [this _resp] this))}
+        bindings (compat/output-bindings msg)]
+    ;; All supported nREPL versions ship the print middleware, so we expect a
+    ;; binding map rather than nil.
+    (is (some? bindings))
+    (is (contains? bindings #'*out*))
+    (is (contains? bindings #'*err*))
+    (is (instance? java.io.Writer (get bindings #'*out*)))
+    (is (instance? java.io.Writer (get bindings #'*err*)))))


### PR DESCRIPTION
First roadmap item (M1). The nREPL-version detection was scattered through the implementation as inline `resolve` checks (`nrepl-1-3+?`, the `replying-PrintWriter` lookup). This pulls them into a dedicated `cider.piggieback.compat` namespace with named, documented predicates, so the eval path stays version-agnostic and there's one place to reason about version differences.

Behavior-preserving refactor; covered by the existing nREPL matrix (1.0 through 1.7) plus a small smoke test for the new namespace.

This is also groundwork: M1 and M2 carve out the seams that make the later eval-ownership refactor (B1) safe.