### PR TITLE
Isolate ClojureScript-internals coupling in a core namespace

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,4 +1,8 @@
-{:linters
+{;; `nrepl.core/code` stringifies its body rather than evaluating it, so the
+ ;; symbols inside (a `cljs.user` ns form) must not be resolved as real code.
+ :lint-as {nrepl.core/code clojure.core/quote}
+
+ :linters
  {;; nREPL handlers destructure many message keys (`session`, `transport`,
   ;; `ns`, ...) and intentionally use only some of them; the rest document the
   ;; message shape.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -304,12 +304,14 @@ roadmap item.
 Piggieback supports a range of nREPL versions (1.0 through current). The
 differences are handled by runtime feature detection (for example resolving
 `interruptible-eval/evaluator` to decide how to bind per-message state, and
-resolving `replying-PrintWriter` for print middleware). These checks are
-currently spread across the implementation; centralizing them is roadmap item M1.
+resolving `replying-PrintWriter` for print middleware). These checks live in one
+place, the `cider.piggieback.compat` namespace (roadmap item M1).
 
 Piggieback also couples tightly to ClojureScript compiler internals
 (`cljs.analyzer`, `cljs.env`, `cljs.closure`, `cljs.tagged-literals`, and the
 non-public parts of `cljs.repl`). This is largely unavoidable given there is no
 public "evaluate a cljs form in this env and hand me the result" API, but it is
-fragile, and isolating it behind one thin, version-guarded namespace is roadmap
-item M2 (and a prerequisite for B1).
+fragile, so it is confined to a single namespace, `cider.piggieback.cljs`, which
+exposes a small Clojure-facing API the middleware talks to instead of reaching
+into the compiler directly (roadmap item M2). That boundary is also what makes
+the planned evaluation-ownership refactor (B1) tractable.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -39,6 +39,9 @@ it has the longest lead time.
   #124).
 - Done: **M1** - cross-nREPL-version compatibility centralized into the
   `cider.piggieback.compat` namespace.
+- Done: **M2** - ClojureScript-internals coupling isolated into the
+  `cider.piggieback.cljs` core namespace; the middleware no longer requires any
+  `cljs.*` namespace directly.
 
 ## Phase 1 - Seams and small modernizations
 
@@ -56,7 +59,7 @@ shims.
 - Risk: low. Pure refactor, behaviour-preserving, fully covered by the nREPL
   matrix in CI.
 
-### M2 - Isolate the ClojureScript-internals coupling
+### M2 - Isolate the ClojureScript-internals coupling (done)
 
 Gather the direct reaches into `cljs.analyzer`, `cljs.env`, `cljs.closure`,
 `cljs.tagged-literals`, and the non-public parts of `cljs.repl` into a single,

--- a/src/cider/piggieback/cljs.clj
+++ b/src/cider/piggieback/cljs.clj
@@ -1,0 +1,275 @@
+(ns cider.piggieback.cljs
+  "The ClojureScript evaluation core.
+
+  All of Piggieback's coupling to the ClojureScript compiler internals
+  (`cljs.repl`, `cljs.analyzer`, `cljs.env`, `cljs.closure`,
+  `cljs.tagged-literals`) lives here, behind a small Clojure-facing API. The
+  nREPL middleware (`cider.piggieback`) talks to this namespace and never
+  reaches into the compiler directly, so the fragile, version-sensitive surface
+  is confined to one place."
+  (:require
+   [clojure.string :as string]
+   [clojure.tools.reader :as reader]
+   [clojure.tools.reader.reader-types :as readers]
+   [cljs.closure]
+   [cljs.repl]
+   [cljs.env :as env]
+   [cljs.analyzer :as ana]
+   [cljs.tagged-literals :as tags])
+  (:import
+   (java.io StringReader)))
+
+;; ---------------------------------------------------------------------------
+;; Analyzer / compiler state
+;; ---------------------------------------------------------------------------
+
+(def ns-var
+  "The ClojureScript analyzer's current-namespace var. Exposed so the middleware
+  can use it as a key in `binding` maps and in the session atom without naming a
+  compiler internal directly."
+  #'ana/*cljs-ns*)
+
+(defn current-ns
+  "The current ClojureScript namespace (a symbol)."
+  []
+  ana/*cljs-ns*)
+
+(defn set-current-ns!
+  "Set the current ClojureScript namespace. Must run on a thread where
+  `ns-var` is bound."
+  [ns-sym]
+  (set! ana/*cljs-ns* ns-sym))
+
+(defn warnings [] ana/*cljs-warnings*)
+
+(defn warning-handlers [] ana/*cljs-warning-handlers*)
+
+(defn eval-bindings
+  "Binding map of the ClojureScript analyzer/compiler dynamic vars needed for a
+  single evaluation. `compiler-env` and `repl-env` come from the session."
+  [compiler-env repl-env]
+  {#'ana/*cljs-warnings* ana/*cljs-warnings*
+   #'ana/*cljs-warning-handlers* ana/*cljs-warning-handlers*
+   #'ana/*unchecked-if* ana/*unchecked-if*
+   #'env/*compiler* compiler-env
+   #'cljs.repl/*repl-env* repl-env})
+
+(defn analyzer-env
+  "An empty analyzer environment scoped to `ns-sym`."
+  [ns-sym]
+  (assoc (ana/empty-env) :ns (ana/get-namespace ns-sym)))
+
+;; ---------------------------------------------------------------------------
+;; REPL options and compiler env
+;; ---------------------------------------------------------------------------
+
+(defn repl-options
+  "The repl-env's own repl options (`cljs.repl/-repl-options`)."
+  [repl-env]
+  (cljs.repl/-repl-options repl-env))
+
+(defn build-opts
+  "Initialise the repl options the way `cljs.repl/repl*` would internally. We
+  evaluate outside of that loop, so we have to do this ourselves."
+  [repl-opts options]
+  (merge
+   {:def-emits-var true}
+   (cljs.closure/add-implicit-options
+    (merge-with (fn [a b] (if (nil? b) a b))
+                repl-opts options))))
+
+(defn default-compiler-env
+  "A fresh ClojureScript compiler environment for `opts`."
+  [opts]
+  (env/default-compiler-env opts))
+
+(defn special-fns
+  "The REPL special functions, merging the cljs defaults with any provided by
+  the repl options."
+  [repl-options]
+  (merge cljs.repl/default-special-fns (:special-fns repl-options)))
+
+(def default-caught
+  "The default `:caught` handler (`cljs.repl/repl-caught`)."
+  cljs.repl/repl-caught)
+
+;; ---------------------------------------------------------------------------
+;; Delegating repl env
+;; ---------------------------------------------------------------------------
+
+;; We wrap the user's repl-env in a delegating env whose only behavioural
+;; difference is a no-op `-tear-down`, so that driving `cljs.repl/repl*` for
+;; setup (which tears the env down when its loop exits) doesn't kill the runtime
+;; we want to keep around for subsequent evaluations.
+
+(defprotocol GetReplEnv
+  (get-repl-env [this]))
+
+(def ^:private cljs-repl-protocol-impls
+  {cljs.repl/IReplEnvOptions
+   {:-repl-options (fn [repl-env] (cljs.repl/-repl-options (get-repl-env repl-env)))}
+   cljs.repl/IParseError
+   {:-parse-error (fn [repl-env err build-options]
+                    (cljs.repl/-parse-error (get-repl-env repl-env) err build-options))}
+   cljs.repl/IGetError
+   {:-get-error (fn [repl-env name env build-options]
+                  (cljs.repl/-get-error (get-repl-env repl-env) name env build-options))}
+   cljs.repl/IParseStacktrace
+   {:-parse-stacktrace (fn [repl-env stacktrace err build-options]
+                         (cljs.repl/-parse-stacktrace (get-repl-env repl-env) stacktrace err build-options))}
+   cljs.repl/IPrintStacktrace
+   {:-print-stacktrace (fn [repl-env stacktrace err build-options]
+                         (cljs.repl/-print-stacktrace (get-repl-env repl-env) stacktrace err build-options))}})
+
+(defn- generate-delegating-repl-env [repl-env]
+  (let [repl-env-class (class repl-env)
+        classname (string/replace (.getName repl-env-class) \. \_)
+        dclassname (str "Delegating" classname)]
+    (eval
+     (list*
+      'deftype (symbol dclassname)
+      '([repl-env]
+        cider.piggieback.cljs/GetReplEnv
+        (get-repl-env [this] (.-repl-env this))
+        cljs.repl/IJavaScriptEnv
+        (-setup [this options] (cljs.repl/-setup repl-env options))
+        (-evaluate [this a b c] (cljs.repl/-evaluate repl-env a b c))
+        (-load [this ns url] (cljs.repl/-load repl-env ns url))
+        ;; This is the whole reason we are creating this delegator
+        ;; to prevent the call to tear-down
+        (-tear-down [_])
+        clojure.lang.ILookup
+        (valAt [_ k] (get repl-env k))
+        (valAt [_ k default] (get repl-env k default))
+        clojure.lang.Seqable
+        (seq [_] (seq repl-env))
+        clojure.lang.Associative
+        (containsKey [_ k] (contains? repl-env k))
+        (entryAt [_ k] (find repl-env k))
+        (assoc [_ k v] (#'cider.piggieback.cljs/delegating-repl-env (assoc repl-env k v)))
+        clojure.lang.IPersistentCollection
+        (count [_] (count repl-env))
+        (cons [_ entry] (conj repl-env entry))
+        ;; pretty meaningless; most REPL envs are records for the assoc'ing, but they're not values
+        (equiv [_ other] false))))
+    (let [dclass (resolve (symbol dclassname))
+          ctor (resolve (symbol (str "->" dclassname)))]
+      (doseq [[protocol fn-map] cljs-repl-protocol-impls]
+        (when (satisfies? protocol repl-env)
+          (extend dclass protocol fn-map)))
+      @ctor)))
+
+(defn delegating-repl-env
+  "Wrap `repl-env` in a delegating env with a no-op `-tear-down`."
+  [repl-env]
+  (let [ctor (generate-delegating-repl-env repl-env)]
+    (ctor repl-env)))
+
+(defn tear-down!
+  "Tear down the (unwrapped) repl env."
+  [repl-env]
+  (cljs.repl/-tear-down repl-env))
+
+;; ---------------------------------------------------------------------------
+;; Reading
+;; ---------------------------------------------------------------------------
+
+(defn read-form
+  "Read a single ClojureScript form from `form-str`, with the cljs data readers
+  and the current namespace's alias map in place. Returns nil for blank input."
+  [form-str]
+  (when-not (string/blank? form-str)
+    (binding [*ns* (create-ns ana/*cljs-ns*)
+              reader/resolve-symbol ana/resolve-symbol
+              reader/*data-readers* tags/*cljs-data-readers*
+              reader/*alias-map*
+              (apply merge
+                     ((juxt :requires :require-macros)
+                      (ana/get-namespace ana/*cljs-ns*)))]
+      (reader/read {:read-cond :allow :features #{:cljs}}
+                   (readers/source-logging-push-back-reader
+                    (StringReader. form-str))))))
+
+;; ---------------------------------------------------------------------------
+;; Result wrapping and evaluation
+;; ---------------------------------------------------------------------------
+
+(defn- wrap-pprint
+  "Wraps sexp with cljs.pprint/pprint in order for it to return a
+  pretty-printed evaluation result as a string."
+  [form]
+  `(let [sb# (goog.string.StringBuffer.)
+         sbw# (cljs.core/StringBufferWriter. sb#)
+         form# ~form]
+     (cljs.pprint/pprint form# sbw#)
+     (cljs.core/str sb#)))
+
+(defn- pprint-repl-wrap-fn [form]
+  (cond
+    (and (seq? form)
+         (#{'ns 'require 'require-macros
+            'use 'use-macros 'import 'refer-clojure} (first form)))
+    identity
+
+    ('#{*1 *2 *3 *e} form) (fn [x]
+                             (wrap-pprint x))
+    :else
+    (fn [x]
+      `(try
+         ~(wrap-pprint
+           `(let [ret# ~x]
+              (set! *3 *2)
+              (set! *2 *1)
+              (set! *1 ret#)
+              ret#))
+         (catch :default e#
+           (set! *e e#)
+           (throw e#))))))
+
+(defn eval-form
+  "Evaluate a single ClojureScript `form` in `repl-env`/`env`. `opts` are the
+  repl options; `print-fn` is the name of nREPL's requested print function, used
+  to pick a result-wrapping strategy."
+  [repl-env env form file opts print-fn]
+  (cljs.repl/evaluate-form
+   repl-env
+   env
+   (or file "<cljs repl>")
+   form
+   ((:wrap opts
+           (if (contains? #{"nrepl.util.print/pr" "cider.nrepl.pprint/pr"} print-fn)
+             #'cljs.repl/wrap-fn
+             #'pprint-repl-wrap-fn))
+    form)
+   opts))
+
+;; ---------------------------------------------------------------------------
+;; REPL setup
+;; ---------------------------------------------------------------------------
+
+(defn setup-repl
+  "Drive `cljs.repl/repl*` through a single setup form (the `cljs.user`
+  namespace require), starting from analyzer namespace `init-ns`. After the
+  setup eval, `on-setup` is called with the resulting analyzer namespace and the
+  compiler env, so the caller can persist them.
+
+  This is the one place we drive the full `repl*` loop rather than evaluating
+  forms ourselves; everything else goes through `eval-form`."
+  [repl-env compiler-env options init-ns code on-setup]
+  (binding [ana/*cljs-ns* init-ns]
+    (with-in-str (str code " :cljs/quit")
+      (cljs.repl/repl*
+       repl-env
+       (merge
+        {:compiler-env compiler-env}
+        ;; if options has a compiler env let it override
+        options
+        ;; these options need to be set to the following values
+        ;; for the repl to initialize correctly
+        {:need-prompt (fn [])
+         :init (fn [])
+         :prompt (fn [])
+         :bind-err false
+         :quit-prompt (fn [])
+         :print (fn [_result & _rest]
+                  (on-setup ana/*cljs-ns* env/*compiler*))})))))

--- a/src/cider/piggieback_impl.clj
+++ b/src/cider/piggieback_impl.clj
@@ -3,14 +3,8 @@
 (require
  '[clojure.main]
  '[clojure.string :as string]
- '[clojure.tools.reader :as reader]
  '[clojure.tools.reader.edn :as edn-reader]
- '[clojure.tools.reader.reader-types :as readers]
- '[cljs.closure]
- '[cljs.repl]
- '[cljs.env :as env]
- '[cljs.analyzer :as ana]
- '[cljs.tagged-literals :as tags]
+ '[cider.piggieback.cljs :as core]
  '[cider.piggieback.compat :as compat]
  '[nrepl.core :as nrepl]
  '[nrepl.middleware.interruptible-eval :as ieval]
@@ -18,7 +12,7 @@
  '[nrepl.transport :as transport])
 
 (import
- '(java.io StringReader Writer))
+ '(java.io Writer))
 
 ;; this is the var that is checked by the middleware to determine whether an
 ;; active CLJS REPL is in flight
@@ -68,32 +62,6 @@
     ;; owned and closed by nREPL, we must not close them here.
     (close [] (.flush ^java.io.Writer @target))))
 
-;; ---------------------------------------------------------------------------
-;; Delegating Repl Env
-;; ---------------------------------------------------------------------------
-
-;; We have to create a delegating ReplEnv to prevent the call to -tear-down
-;; this could be avoided if we could override -tear-down only
-
-(defprotocol GetReplEnv
-  (get-repl-env [this]))
-
-(def ^:private cljs-repl-protocol-impls
-  {cljs.repl/IReplEnvOptions
-   {:-repl-options (fn [repl-env] (cljs.repl/-repl-options (get-repl-env repl-env)))}
-   cljs.repl/IParseError
-   {:-parse-error (fn [repl-env err build-options]
-                    (cljs.repl/-parse-error (get-repl-env repl-env) err build-options))}
-   cljs.repl/IGetError
-   {:-get-error (fn [repl-env name env build-options]
-                  (cljs.repl/-get-error (get-repl-env repl-env) name env build-options))}
-   cljs.repl/IParseStacktrace
-   {:-parse-stacktrace (fn [repl-env stacktrace err build-options]
-                         (cljs.repl/-parse-stacktrace (get-repl-env repl-env) stacktrace err build-options))}
-   cljs.repl/IPrintStacktrace
-   {:-print-stacktrace (fn [repl-env stacktrace err build-options]
-                         (cljs.repl/-print-stacktrace (get-repl-env repl-env) stacktrace err build-options))}})
-
 (deftype ^:private UnknownTaggedLiteral [tag data])
 
 (defmethod print-method UnknownTaggedLiteral
@@ -106,50 +74,6 @@
   (.write w " ")
   (print-method (.data this) w))
 
-(defn- generate-delegating-repl-env [repl-env]
-  (let [repl-env-class (class repl-env)
-        classname (string/replace (.getName repl-env-class) \. \_)
-        dclassname (str "Delegating" classname)]
-    (eval
-     (list*
-      'deftype (symbol dclassname)
-      '([repl-env]
-        cider.piggieback/GetReplEnv
-        (get-repl-env [this] (.-repl-env this))
-        cljs.repl/IJavaScriptEnv
-        (-setup [this options] (cljs.repl/-setup repl-env options))
-        (-evaluate [this a b c] (cljs.repl/-evaluate repl-env a b c))
-        (-load [this ns url] (cljs.repl/-load repl-env ns url))
-        ;; This is the whole reason we are creating this delegator
-        ;; to prevent the call to tear-down
-        (-tear-down [_])
-        clojure.lang.ILookup
-        (valAt [_ k] (get repl-env k))
-        (valAt [_ k default] (get repl-env k default))
-        clojure.lang.Seqable
-        (seq [_] (seq repl-env))
-        clojure.lang.Associative
-        (containsKey [_ k] (contains? repl-env k))
-        (entryAt [_ k] (find repl-env k))
-        (assoc [_ k v] (#'cider.piggieback/delegating-repl-env (assoc repl-env k v)))
-        clojure.lang.IPersistentCollection
-        (count [_] (count repl-env))
-        (cons [_ entry] (conj repl-env entry))
-        ;; pretty meaningless; most REPL envs are records for the assoc'ing, but they're not values
-        (equiv [_ other] false))))
-    (let [dclass (resolve (symbol dclassname))
-          ctor (resolve (symbol (str "->" dclassname)))]
-      (doseq [[protocol fn-map] cljs-repl-protocol-impls]
-        (when (satisfies? protocol repl-env)
-          (extend dclass protocol fn-map)))
-      @ctor)))
-
-(defn- delegating-repl-env [repl-env]
-  (let [ctor (generate-delegating-repl-env repl-env)]
-    (ctor repl-env)))
-
-;; ---------------------------------------------------------------------------
-
 (defn repl-caught [session transport nrepl-msg err repl-env repl-options]
   (let [root-ex (#'clojure.main/root-cause err)]
     (when-not (instance? ThreadDeath root-ex)
@@ -158,31 +82,7 @@
       (transport/send transport (response-for nrepl-msg {:status :eval-error
                                                          :ex (-> err class str)
                                                          :root-ex (-> root-ex class str)}))
-      ((:caught repl-options cljs.repl/repl-caught) err repl-env repl-options))))
-
-(defn- run-cljs-repl [{:keys [session transport ns]}
-                      code repl-env compiler-env options]
-  (let [initns (if ns (symbol ns) (@session #'ana/*cljs-ns*))
-        repl cljs.repl/repl*]
-    (binding [ana/*cljs-ns* initns]
-      (with-in-str (str code " :cljs/quit")
-        (repl repl-env
-              (merge
-               {:compiler-env compiler-env}
-               ;; if options has a compiler env let it override
-               options
-               ;; these options need to be set to the following values
-               ;; for the repl to initialize correctly
-               {:need-prompt (fn [])
-                :init (fn [])
-                :prompt (fn [])
-                :bind-err false
-                :quit-prompt (fn [])
-                :print (fn [_result & _rest]
-                         (when (or (not ns)
-                                   (not= initns ana/*cljs-ns*))
-                           (swap! session assoc #'ana/*cljs-ns* ana/*cljs-ns*))
-                         (set! *cljs-compiler-env* env/*compiler*))}))))))
+      ((:caught repl-options core/default-caught) err repl-env repl-options))))
 
 ;; This function always executes when the nREPL session is evaluating Clojure,
 ;; via interruptible-eval, etc. This means our dynamic environment is in place,
@@ -207,23 +107,21 @@
                  ":repl-options :init, both of which run outside of any session.")
             {:repl-env repl-env})))
   (try
-    (let [repl-opts (cljs.repl/-repl-options repl-env)
-          repl-env (delegating-repl-env repl-env)
+    (let [repl-opts (core/repl-options repl-env)
+          repl-env (core/delegating-repl-env repl-env)
           ;; have to initialise repl-options the same way they
           ;; are initilized inside of the cljs.repl/repl loop
           ;; because we are calling evaluate outside of the repl
           ;; loop.
-          opts (merge
-                {:def-emits-var true}
-                (cljs.closure/add-implicit-options
-                 (merge-with (fn [a b] (if (nil? b) a b))
-                             repl-opts options)))
+          opts (core/build-opts repl-opts options)
           ;; Create the compiler env up front and hand it to the repl loop so we
           ;; always hold a reference to it, even if the setup eval errors and the
           ;; loop's :print callback (which would otherwise capture it) never runs
           ;; (issue #62).
-          compiler-env (or (:compiler-env options) (env/default-compiler-env opts))]
-      (set! ana/*cljs-ns* 'cljs.user)
+          compiler-env (or (:compiler-env options) (core/default-compiler-env opts))
+          {:keys [session ns]} ieval/*msg*
+          init-ns (if ns (symbol ns) (get @session core/ns-var))]
+      (core/set-current-ns! 'cljs.user)
       (let [out-target (atom *out*)
             err-target (atom *err*)]
         ;; Set up the repl env with forwarding writers in place so its
@@ -231,32 +129,35 @@
         ;; than to the one that started the REPL (issue #111).
         (binding [*out* (forwarding-writer out-target)
                   *err* (forwarding-writer err-target)]
-          ;; this will implicitly set! *cljs-compiler-env*
-          (run-cljs-repl ieval/*msg*
-                         ;; this is needed to respect :repl-requires
-                         (if-let [requires (not-empty (:repl-requires opts))]
-                           (pr-str (cons 'ns `(cljs.user (:require ~@requires
-                                                                   [~'cljs.repl :refer-macros [~'source ~'doc ~'find-doc
-                                                                                               ~'apropos ~'dir ~'pst]]
-                                                                   [~'cljs.pprint]))))
-                           (nrepl/code (ns cljs.user
-                                         (:require [cljs.repl :refer-macros [source doc find-doc
-                                                                             apropos dir pst]]
-                                                   [cljs.pprint]))))
-                         repl-env compiler-env options))
+          (core/setup-repl
+           repl-env compiler-env options init-ns
+           ;; this is needed to respect :repl-requires
+           (if-let [requires (not-empty (:repl-requires opts))]
+             (pr-str (cons 'ns `(cljs.user (:require ~@requires
+                                                     [~'cljs.repl :refer-macros [~'source ~'doc ~'find-doc
+                                                                                 ~'apropos ~'dir ~'pst]]
+                                                     [~'cljs.pprint]))))
+             (nrepl/code (ns cljs.user
+                           (:require [cljs.repl :refer-macros [source doc find-doc
+                                                               apropos dir pst]]
+                                     [cljs.pprint]))))
+           ;; implicitly records the compiler env and tracks the namespace
+           (fn [result-ns result-compiler-env]
+             (when (or (not ns) (not= init-ns result-ns))
+               (swap! session assoc core/ns-var result-ns))
+             (set! *cljs-compiler-env* result-compiler-env))))
         (set! *cljs-out-target* out-target)
         (set! *cljs-err-target* err-target))
-      ;; (clojure.pprint/pprint (:options @*cljs-compiler-env*))
       ;; Record the compiler env unconditionally, in case the setup eval errored
-      ;; and the :print callback never set it (issue #62).
+      ;; and the on-setup callback never set it (issue #62).
       (set! *cljs-compiler-env* compiler-env)
       (set! *cljs-repl-env* repl-env)
       (set! *cljs-repl-options* opts)
       ;; interruptible-eval is in charge of emitting the final :ns response in this context
       (set! *original-clj-ns* *ns*)
-      (set! *cljs-warnings* ana/*cljs-warnings*)
-      (set! *cljs-warning-handlers* ana/*cljs-warning-handlers*)
-      (set! *ns* (find-ns ana/*cljs-ns*))
+      (set! *cljs-warnings* (core/warnings))
+      (set! *cljs-warning-handlers* (core/warning-handlers))
+      (set! *ns* (find-ns (core/current-ns)))
       (println "To quit, type:" :cljs/quit))
     (catch Exception e
       (set! *cljs-repl-env* nil)
@@ -275,85 +176,32 @@
             #(transport/send transport (response-for msg :status :done))))))
 
 (defn read-cljs-string [form-str]
-  (when-not (string/blank? form-str)
-    (binding [*ns* (create-ns ana/*cljs-ns*)
-              reader/resolve-symbol ana/resolve-symbol
-              reader/*data-readers* tags/*cljs-data-readers*
-              reader/*alias-map*
-              (apply merge
-                     ((juxt :requires :require-macros)
-                      (ana/get-namespace ana/*cljs-ns*)))]
-      (reader/read {:read-cond :allow :features #{:cljs}}
-                   (readers/source-logging-push-back-reader
-                    (StringReader. form-str))))))
-
-(defn- wrap-pprint
-  "Wraps sexp with cljs.pprint/pprint in order for it to return a
-  pretty-printed evaluation result as a string."
-  [form]
-  `(let [sb# (goog.string.StringBuffer.)
-         sbw# (cljs.core/StringBufferWriter. sb#)
-         form# ~form]
-     (cljs.pprint/pprint form# sbw#)
-     (cljs.core/str sb#)))
-
-(defn- pprint-repl-wrap-fn [form]
-  (cond
-    (and (seq? form)
-         (#{'ns 'require 'require-macros
-            'use 'use-macros 'import 'refer-clojure} (first form)))
-    identity
-
-    ('#{*1 *2 *3 *e} form) (fn [x]
-                             (wrap-pprint x))
-    :else
-    (fn [x]
-      `(try
-         ~(wrap-pprint
-           `(let [ret# ~x]
-              (set! *3 *2)
-              (set! *2 *1)
-              (set! *1 ret#)
-              ret#))
-         (catch :default e#
-           (set! *e e#)
-           (throw e#))))))
+  (core/read-form form-str))
 
 (defn eval-cljs [repl-env env form file opts]
-  (cljs.repl/evaluate-form repl-env
-                           env
-                           (or file "<cljs repl>")
-                           form
-                           ((:wrap opts
-                                   (if (contains? #{"nrepl.util.print/pr" "cider.nrepl.pprint/pr"} (::print opts))
-                                     #'cljs.repl/wrap-fn
-                                     #'pprint-repl-wrap-fn)) form)
-                           opts))
+  (core/eval-form repl-env env form file opts (::print opts)))
 
 (defn do-eval [{:keys [session transport ^String code file ns] :as msg}]
-  (with-bindings (merge {#'ana/*cljs-warnings* ana/*cljs-warnings*
-                         #'ana/*cljs-warning-handlers* ana/*cljs-warning-handlers*
-                         #'ana/*unchecked-if* ana/*unchecked-if*
-                         #'env/*compiler* (get @session #'*cljs-compiler-env*)
-                         #'cljs.repl/*repl-env* (get @session #'*cljs-repl-env*)}
+  (with-bindings (merge (core/eval-bindings (get @session #'*cljs-compiler-env*)
+                                            (get @session #'*cljs-repl-env*))
                         ;; On nREPL 1.3+ the session middleware already binds the
                         ;; session contents, so we must not rebind them here.
                         (when-not compat/nrepl-1-3+?
                           @session)
                         (when ns
-                          {#'ana/*cljs-ns* (symbol ns)})
+                          {core/ns-var (symbol ns)})
                         (compat/output-bindings msg))
     ;; Repoint the repl env's output-pump thread at this message's output (#111).
     (when *cljs-out-target* (reset! *cljs-out-target* *out*))
     (when *cljs-err-target* (reset! *cljs-err-target* *err*))
     (let [repl-env *cljs-repl-env*
           repl-options *cljs-repl-options*
-          init-ns ana/*cljs-ns*
-          special-fns (merge cljs.repl/default-special-fns (:special-fns repl-options))
+          init-ns (core/current-ns)
+          special-fns (core/special-fns repl-options)
           is-special-fn? (set (keys special-fns))]
       (try
         (let [form (read-cljs-string code)
-              env  (assoc (ana/empty-env) :ns (ana/get-namespace init-ns))
+              env  (core/analyzer-env init-ns)
               result (when form
                        (if (and (seq? form) (is-special-fn? (first form)))
                          (do ((get special-fns (first form)) repl-env env form repl-options)
@@ -368,9 +216,9 @@
           (.flush ^Writer *out*)
           (.flush ^Writer *err*)
           (when (and (or (not ns)
-                         (not= init-ns ana/*cljs-ns*))
-                     ana/*cljs-ns*)
-            (swap! session assoc #'ana/*cljs-ns* ana/*cljs-ns*))
+                         (not= init-ns (core/current-ns)))
+                     (core/current-ns))
+            (swap! session assoc core/ns-var (core/current-ns)))
           (transport/send
            transport
            (response-for msg
@@ -380,10 +228,10 @@
                                       {:default ->UnknownTaggedLiteral}
                                       result))
                             :nrepl.middleware.print/keys #{:value}
-                            :ns ana/*cljs-ns*}
+                            :ns (core/current-ns)}
                            (catch Exception _
                              {:value (or result "nil")
-                              :ns ana/*cljs-ns*})))))
+                              :ns (core/current-ns)})))))
         (catch Throwable t
           (repl-caught session transport msg t repl-env repl-options))))))
 
@@ -395,15 +243,15 @@
   (if-not (-> code string/trim (string/ends-with? ":cljs/quit"))
     (do-eval msg)
 
-    (let [actual-repl-env (get-repl-env (@session #'*cljs-repl-env*))
+    (let [actual-repl-env (core/get-repl-env (@session #'*cljs-repl-env*))
           orig-ns (@session #'*original-clj-ns*)]
-      (cljs.repl/-tear-down actual-repl-env)
+      (core/tear-down! actual-repl-env)
       (swap! session assoc
              #'*ns* orig-ns
              #'*cljs-repl-env* nil
              #'*cljs-compiler-env* nil
              #'*cljs-repl-options* nil
-             #'ana/*cljs-ns* 'cljs.user)
+             core/ns-var 'cljs.user)
       (when (thread-bound? #'*ns*)
         (set! *ns* orig-ns))
       (transport/send transport (response-for msg
@@ -438,5 +286,5 @@
                                        #'*cljs-out-target* *cljs-out-target*
                                        #'*cljs-err-target* *cljs-err-target*
                                        #'*original-clj-ns* *ns*
-                                       #'ana/*cljs-ns* ana/*cljs-ns*})))
+                                       core/ns-var (core/current-ns)})))
       (handler msg))))


### PR DESCRIPTION
Roadmap item M2, and the prerequisite seam for the later eval-ownership refactor (B1).

All of Piggieback's coupling to the ClojureScript compiler internals (`cljs.repl`, `cljs.analyzer`, `cljs.env`, `cljs.closure`, `cljs.tagged-literals`) is pulled behind a small Clojure-facing API in the new `cider.piggieback.cljs` namespace. The nREPL middleware now talks to that core and no longer requires any `cljs.*` namespace directly, so the fragile, version-sensitive surface lives in one file.

Behavior-preserving extraction. The public API (`cljs-repl`, `do-eval`, `eval-cljs`, `read-cljs-string`, `repl-caught`, `wrap-cljs-repl`) stays in `cider.piggieback`, now delegating to the core. The one tricky bit was setup: `cider.piggieback.cljs/setup-repl` drives `cljs.repl/repl*` and hands the resulting ns + compiler env back to the caller via a callback, keeping all session/transport orchestration in the middleware.

Verified against the full nREPL matrix plus the node-backed test suite.