### PR TITLE
Document the interrupt limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,17 @@ the above fallbacks are being used instead.
 **Note:** See [this pull request](https://github.com/nrepl/piggieback/pull/108)
 for more background and discussion on the current solution.
 
+### Interrupting evaluation
+
+nREPL's `interrupt` op does not meaningfully apply to ClojureScript
+evaluation. A ClojureScript form is compiled on the JVM and then handed off to
+the JavaScript runtime (Node, the browser, ...), which executes it in a single
+thread that Piggieback does not control. There is no portable way to interrupt
+code already running in that runtime, so a long-running or non-terminating
+ClojureScript expression cannot be cancelled from the editor the way a Clojure
+one can. If you evaluate something that hangs, you'll generally need to restart
+the JavaScript runtime (and the REPL on top of it).
+
 ## FAQ
 
 ### Why "piggieback" instead of "piggyback"?

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -297,7 +297,8 @@ roadmap item.
   evaluated, because steady-state eval does not spin a fresh `cljs.repl` per
   message (see the README Design section).
 - **Interrupt.** A long-running JS eval cannot be cancelled cleanly. This is
-  largely inherent to single-threaded JS runtimes but is currently undocumented.
+  largely inherent to single-threaded JS runtimes; it is documented in the
+  README ("Interrupting evaluation").
 
 ## Compatibility surface
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -42,6 +42,7 @@ it has the longest lead time.
 - Done: **M2** - ClojureScript-internals coupling isolated into the
   `cider.piggieback.cljs` core namespace; the middleware no longer requires any
   `cljs.*` namespace directly.
+- Done: **M5** - the interrupt limitation is documented in the README.
 
 ## Phase 1 - Seams and small modernizations
 
@@ -90,7 +91,7 @@ more robust signal for choosing plain vs pretty printing.
 - Why: the present check breaks the moment a different pretty-printer is used.
 - Risk: low.
 
-### M5 - Document the interrupt limitation
+### M5 - Document the interrupt limitation (done)
 
 A long-running JS eval cannot be cancelled cleanly. Document this clearly rather
 than leaving it implicit, and decide whether any best-effort behaviour is worth


### PR DESCRIPTION
Roadmap item M5. Adds a short README section explaining that nREPL's `interrupt` op can't cancel a running ClojureScript evaluation (the code runs in the JS runtime, on a thread Piggieback doesn't control), so a hanging expression needs a runtime restart. Docs only.