### PR TITLE
Surface ClojureScript state in the describe response

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,9 +89,11 @@ Piggieback operates at the nREPL *session* level. Clients do not pass an
 `:env :cljs` parameter or call a dedicated op; they just keep using `eval` with a
 session that has a ClojureScript REPL active. This is what makes a mixed
 Clojure/ClojureScript server transparent to tooling. The price is that
-ClojureScript-ness is implicit: nothing in the protocol (for example the
-`describe` response) currently advertises that a session is in ClojureScript
-mode, so tools infer it out of band. (See roadmap item M3.)
+ClojureScript-ness is implicit in the eval flow: clients don't flag a message as
+cljs. To let tooling detect it from the protocol rather than out of band,
+Piggieback contributes its per-session status (whether a cljs REPL is active, and
+which repl-env) to the `describe` response's `:aux` map via a `:describe-fn`.
+(See roadmap item M3.)
 
 ### Dynamic vars as session state
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -43,6 +43,8 @@ it has the longest lead time.
   `cider.piggieback.cljs` core namespace; the middleware no longer requires any
   `cljs.*` namespace directly.
 - Done: **M5** - the interrupt limitation is documented in the README.
+- Done: **M3** - the `describe` response surfaces per-session ClojureScript
+  status via a `:describe-fn`.
 
 ## Phase 1 - Seams and small modernizations
 
@@ -73,7 +75,7 @@ that core, not to compiler internals directly.
   lean on the existing tests and add characterization tests where thin.
 - Prerequisite for: B1.
 
-### M3 - Surface ClojureScript state in `describe`
+### M3 - Surface ClojureScript state in `describe` (done)
 
 Advertise Piggieback in the `describe` response and expose whether a session is
 currently in ClojureScript mode (and ideally which repl-env). Optionally echo

--- a/src/cider/piggieback.clj
+++ b/src/cider/piggieback.clj
@@ -27,4 +27,6 @@
                  {:requires #{"clone" #'print/wrap-print}
                   ;; piggieback unconditionally hijacks eval and load-file
                   :expects #{"eval" "load-file"}
-                  :handles {}})
+                  :handles {}
+                  ;; contributes the session's ClojureScript status to `describe`
+                  :describe-fn describe-cljs})

--- a/src/cider/piggieback_impl.clj
+++ b/src/cider/piggieback_impl.clj
@@ -269,6 +269,19 @@
 (defn- load-file [{:keys [session transport file-path] :as msg}]
   (evaluate (assoc msg :code (format "(load-file %s)" (pr-str file-path)))))
 
+(defn describe-cljs
+  "A describe-fn (see nREPL's `wrap-describe`) that contributes Piggieback's
+  per-session ClojureScript status to the `describe` response's `:aux` map.
+
+  Lets tooling detect that Piggieback is present and whether the session is
+  currently evaluating ClojureScript (and against which repl-env), instead of
+  having to infer it out of band."
+  [{:keys [session]}]
+  (let [repl-env (when session (get @session #'*cljs-repl-env*))]
+    {:piggieback (cond-> {:cljs-repl (if repl-env "active" "inactive")}
+                   repl-env (assoc :repl-env-type
+                                   (.getName (class (core/get-repl-env repl-env)))))}))
+
 (defn wrap-cljs-repl [handler]
   (fn [{:keys [session op] :as msg}]
     (let [handler (or (when-let [f (and (@session #'*cljs-repl-env*)

--- a/src/cider/piggieback_shim.clj
+++ b/src/cider/piggieback_shim.clj
@@ -12,6 +12,12 @@
 (def eval-cljs fail-to-call)
 (def do-eval fail-to-call)
 
+(defn describe-cljs
+  "A describe-fn reporting that ClojureScript support is unavailable: this shim
+  is loaded precisely because ClojureScript is not on the classpath."
+  [_msg]
+  {:piggieback {:cljs-repl "unavailable"}})
+
 (defn wrap-cljs-repl [handler]
   (fn [msg]
     (handler msg)))

--- a/test/cider/piggieback_test.clj
+++ b/test/cider/piggieback_test.clj
@@ -112,6 +112,18 @@
     (testing (pr-str response)
       (is (= "cljs.user" (:ns response))))))
 
+;; Piggieback contributes its per-session ClojureScript status to nREPL's
+;; `describe` response, so tooling can detect cljs mode from the protocol rather
+;; than inferring it. The fixture has an active node REPL, so describe should
+;; report it as such.
+(deftest describe-surfaces-cljs-state
+  (let [response (-> (nrepl/message *session* {:op "describe"})
+                     nrepl/combine-responses)
+        pb (get-in response [:aux :piggieback])]
+    (testing (pr-str response)
+      (is (= "active" (:cljs-repl pb)))
+      (is (= "cljs.repl.node.NodeEnv" (:repl-env-type pb))))))
+
 ;; The forwarding writer stands in for *out*/*err* while the repl env is set up,
 ;; so it must cope with every way Clojure and the repl env write to it, not just
 ;; the (char[], off, len) arity the Node output pump happens to use.


### PR DESCRIPTION
Roadmap item M3. Piggieback now contributes a `:describe-fn` to its middleware descriptor, so the `describe` response's `:aux` map gains a `:piggieback` entry reporting whether a cljs REPL is active in the session and, if so, the repl-env type (e.g. `cljs.repl.node.NodeEnv`). Tools can detect cljs mode from the protocol instead of inferring it out of band; the no-cljs shim reports `:cljs-repl "unavailable"`.

`:describe-fn` is supported back to nREPL 1.0, and older servers would just ignore an unknown descriptor key anyway, so it's safe across the matrix. Tested via a `describe` op against the active node fixture.