### PR TITLE
Tear down the cljs REPL when its session is closed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## unreleased
 
+* Tear down an active ClojureScript REPL when its nREPL session is closed, so the JavaScript runtime (e.g. a Node subprocess) doesn't leak when a client disconnects without `:cljs/quit`.
+* Surface ClojureScript status (whether a session has an active cljs REPL, and the repl-env type) in the nREPL `describe` response's `:aux` map.
+
 ## 0.6.2 (2026-06-27)
 
 * [#124](https://github.com/nrepl/piggieback/issues/124): Throw a clear error when `cljs-repl` is invoked outside of an nREPL session (e.g. from Leiningen's `:repl-options :init`) instead of a cryptic "Can't change/establish root binding".

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -205,7 +205,7 @@ Note the two distinct evaluation paths (setup via `repl*`, steady-state via
 `evaluate-form`). That split is the source of much of Piggieback's incidental
 complexity and is the target of the largest planned refactor (roadmap item B1).
 
-### Session REPL state and the teardown gap
+### Session REPL state and teardown
 
 ```mermaid
 stateDiagram-v2
@@ -213,21 +213,30 @@ stateDiagram-v2
     Clojure --> ClojureScript: cljs-repl invoked (sets *cljs-repl-env*)
     ClojureScript --> ClojureScript: eval / load-file routed to Piggieback
     ClojureScript --> Clojure: ":cljs/quit" (-tear-down, vars reset)
+    ClojureScript --> [*]: session closed (-tear-down via :close hook)
     Clojure --> [*]: session closed
 
     note right of ClojureScript
-      Gap: if a session is closed
-      (or the client disconnects)
-      while here, -tear-down is
-      never called and the JS
-      runtime leaks. Roadmap C1.
+      Closing the session while a
+      cljs REPL is active also tears
+      the runtime down, via the
+      session's :close meta hook
+      (roadmap C1).
     end note
 ```
 
-Teardown currently happens only on an explicit `:cljs/quit`. There is no hook on
-session close or expiry, so a dropped connection leaves the node subprocess or
-browser connection running. This is a real correctness gap, tracked as roadmap
-item C1.
+Teardown happens on an explicit `:cljs/quit` and also when the session is closed
+while a cljs REPL is active. Since nREPL's session middleware handles the `close`
+op itself and never delegates it to Piggieback, the latter is wired by composing
+a teardown into the session's `:close` metadata fn (the one
+`nrepl.middleware.session/close-session` invokes) when the REPL starts. This
+keeps a client that closes its session (or exits) without `:cljs/quit` from
+leaking the JavaScript runtime (roadmap item C1).
+
+Note this covers session *close*, not a silently dropped TCP connection: nREPL
+sessions deliberately outlive their connection (so you can reconnect, as the
+output-routing test exercises), so a dropped connection alone does not close the
+session or trigger teardown.
 
 ## Implementation mechanisms
 
@@ -294,7 +303,10 @@ roadmap item.
   from `file-path` on disk rather than evaluating the source sent in the message,
   which diverges from Clojure nREPL semantics (loading an unsaved buffer loads the
   saved version). Roadmap C2.
-- **No session-close teardown.** See the state diagram above; roadmap C1.
+- **Dropped connections.** Session close now tears the runtime down (roadmap
+  C1), but a silently dropped TCP connection does not close the session, so it
+  cannot trigger teardown; such a session lingers until an explicit close or
+  server shutdown.
 - **Multi-form evaluation.** Only the first form of a multi-form string is
   evaluated, because steady-state eval does not spin a fresh `cljs.repl` per
   message (see the README Design section).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -45,6 +45,8 @@ it has the longest lead time.
 - Done: **M5** - the interrupt limitation is documented in the README.
 - Done: **M3** - the `describe` response surfaces per-session ClojureScript
   status via a `:describe-fn`.
+- Done: **C1** - closing a session tears down an active ClojureScript repl-env,
+  via the session's `:close` metadata hook.
 
 ## Phase 1 - Seams and small modernizations
 
@@ -106,7 +108,7 @@ offering.
 
 Independent of everything else; ship as soon as ready.
 
-### C1 - Tear down on session close
+### C1 - Tear down on session close (done)
 
 Register cleanup on session close / expiry so the active repl-env's `-tear-down`
 runs even when the client never sends `:cljs/quit` (dropped connection, editor

--- a/src/cider/piggieback_impl.clj
+++ b/src/cider/piggieback_impl.clj
@@ -84,6 +84,33 @@
                                                          :root-ex (-> root-ex class str)}))
       ((:caught repl-options core/default-caught) err repl-env repl-options))))
 
+(defn- ensure-close-teardown!
+  "Augment the session's `:close` metadata (once) so that closing the session
+  also tears down any active ClojureScript repl-env.
+
+  nREPL's session middleware handles the `close` op itself and never delegates
+  it to Piggieback, so we can't intercept it as an op. Instead we compose our
+  teardown into the `:close` fn that `nrepl.middleware.session/close-session`
+  invokes. Without this, closing a session (or a client exiting) without first
+  sending `:cljs/quit` leaks the JavaScript runtime, e.g. a Node subprocess."
+  [session]
+  (when-not (::close-hooked (meta session))
+    (alter-meta!
+     session
+     (fn [m]
+       (let [orig-close (:close m)]
+         (assoc m
+                ::close-hooked true
+                :close (fn []
+                         ;; Read the repl-env at close time so that a prior
+                         ;; :cljs/quit (which nils it out) means we don't try to
+                         ;; tear an already-torn-down runtime down again.
+                         (try
+                           (when-let [repl-env (@session #'*cljs-repl-env*)]
+                             (core/tear-down! (core/get-repl-env repl-env)))
+                           (catch Throwable _))
+                         (when orig-close (orig-close)))))))))
+
 ;; This function always executes when the nREPL session is evaluating Clojure,
 ;; via interruptible-eval, etc. This means our dynamic environment is in place,
 ;; so set! and simple dereferencing is available. Contrast w/ evaluate and
@@ -158,6 +185,9 @@
       (set! *cljs-warnings* (core/warnings))
       (set! *cljs-warning-handlers* (core/warning-handlers))
       (set! *ns* (find-ns (core/current-ns)))
+      ;; make sure a leaked JS runtime is torn down if the session is closed
+      ;; without a :cljs/quit first
+      (ensure-close-teardown! session)
       (println "To quit, type:" :cljs/quit))
     (catch Exception e
       (set! *cljs-repl-env* nil)

--- a/test/cider/piggieback_close_test.clj
+++ b/test/cider/piggieback_close_test.clj
@@ -1,0 +1,45 @@
+(ns cider.piggieback-close-test
+  "Regression test: closing an nREPL session must tear down an active
+  ClojureScript repl-env, so a client that closes (or exits) without sending
+  `:cljs/quit` doesn't leak the JavaScript runtime.
+
+  Node-free: a `RecordingEnv` stands in for a real repl-env and records whether
+  it was torn down, so we don't need (and can't have, per the cljs.repl.node
+  global-state limitation) a second live Node REPL alongside the main fixture."
+  (:require
+   [clojure.test :refer [deftest is]]
+   [cider.piggieback]
+   [cider.piggieback.cljs :as core]
+   [cljs.repl]))
+
+(defrecord RecordingEnv [torn-down?]
+  core/GetReplEnv
+  (get-repl-env [this] this)
+  cljs.repl/IJavaScriptEnv
+  (-setup [_ _])
+  (-evaluate [_ _ _ _])
+  (-load [_ _ _])
+  (-tear-down [_] (reset! torn-down? true)))
+
+(deftest closing-session-tears-down-active-cljs-repl
+  (let [torn? (atom false)
+        orig-closed? (atom false)
+        session (atom {#'cider.piggieback/*cljs-repl-env* (->RecordingEnv torn?)}
+                      :meta {:id "s" :close #(reset! orig-closed? true)})
+        ensure-close-teardown! @#'cider.piggieback/ensure-close-teardown!]
+    (ensure-close-teardown! session)
+    ;; simulate nREPL's close-session, which invokes the session's :close meta
+    ((:close (meta session)))
+    (is (true? @torn?) "the active cljs repl-env was torn down")
+    (is (true? @orig-closed?) "the original session :close still ran")))
+
+(deftest teardown-hook-is-idempotent-and-safe-when-inactive
+  (let [orig-closed? (atom false)
+        ;; no active cljs repl-env in the session
+        session (atom {} :meta {:id "s" :close #(reset! orig-closed? true)})
+        ensure-close-teardown! @#'cider.piggieback/ensure-close-teardown!]
+    (ensure-close-teardown! session)
+    ;; hooking twice must not stack wrappers
+    (ensure-close-teardown! session)
+    ((:close (meta session)))
+    (is (true? @orig-closed?) "closing still works with no active cljs repl")))


### PR DESCRIPTION
Roadmap item C1, a real resource-leak fix.

If a client closes its nREPL session (or exits) without first sending `:cljs/quit`, the active ClojureScript repl-env was never torn down, leaking the JavaScript runtime (a Node subprocess, a browser connection, ...). nREPL's session middleware handles the `close` op itself and never delegates it to Piggieback, so it can't be intercepted as an op. Instead we compose our teardown into the session's `:close` metadata fn (the one `nrepl.middleware.session/close-session` invokes) when the cljs REPL starts.

The teardown reads the repl-env at close time, so a prior `:cljs/quit` (which nils it out) means we don't double-tear-down, and the hook is installed only once per session.

Tested node-free with a recording env that implements both `GetReplEnv` and `IJavaScriptEnv` (a second live Node REPL alongside the fixture isn't possible given the cljs.repl.node global-state limitation). One known boundary, documented: a silently dropped TCP connection doesn't close the session, so it can't trigger teardown.