### PR TITLE
Make load-file evaluate the source sent in the message

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+* `load-file` now evaluates the source sent in the message (the editor's buffer, including unsaved changes) instead of re-reading the file from disk, matching nREPL's behaviour on Clojure.
 * Tear down an active ClojureScript REPL when its nREPL session is closed, so the JavaScript runtime (e.g. a Node subprocess) doesn't leak when a client disconnects without `:cljs/quit`.
 * Surface ClojureScript status (whether a session has an active cljs REPL, and the repl-env type) in the nREPL `describe` response's `:aux` map.
 

--- a/README.md
+++ b/README.md
@@ -153,10 +153,7 @@ REPL are evaluated within the ClojureScript environment.
    `target/classes/public`, etc). Either configure your ring app to serve
    resources from `out`, or pass a `cljs-repl` `:output-dir` option so that a
    reasonable correspondence is established.
-2. The `load-file` nREPL operation will only load the state of files from disk.
-   This is in contrast to "regular" Clojure nREPL operation, where the current
-   state of a file's buffer is loaded without regard to its saved state on disk.
-3. `cider.piggieback/cljs-repl` has to be invoked from within an nREPL session
+2. `cider.piggieback/cljs-repl` has to be invoked from within an nREPL session
    (e.g. evaluated at a connected REPL). It can't be started from Leiningen's
    `:repl-options :init`, which runs at startup before any session exists;
    attempting to do so fails with an error explaining as much.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -288,6 +288,15 @@ ClojureScript REPL special functions (`cljs.repl/default-special-fns`, merged
 with any from the repl options) are dispatched directly rather than evaluated, so
 things like `load-file`, `in-ns`, and `require` behave like REPL specials.
 
+### Loading a file
+
+The `load-file` op evaluates the source sent in the message (its `:file`), using
+`cljs.repl/load-stream` to read and evaluate every top-level form against the
+active repl-env, with the analyzer namespace restored afterwards. This loads the
+client's buffer content, including unsaved changes, matching Clojure nREPL
+semantics. If a message arrives without `:file` content, Piggieback falls back to
+the cljs `load-file` special function, which reads from disk (roadmap item C2).
+
 ## Structural constraints and known gaps
 
 These are limitations that are either upstream or architectural; each maps to a
@@ -299,10 +308,6 @@ roadmap item.
 - **`*out*` capture.** The forwarding-writer machinery exists only to compensate
   for the node env capturing `*out*` at setup. The clean fix is upstream; roadmap
   U2.
-- **`load-file` loads from disk.** Piggieback's `load-file` re-reads the file
-  from `file-path` on disk rather than evaluating the source sent in the message,
-  which diverges from Clojure nREPL semantics (loading an unsaved buffer loads the
-  saved version). Roadmap C2.
 - **Dropped connections.** Session close now tears the runtime down (roadmap
   C1), but a silently dropped TCP connection does not close the session, so it
   cannot trigger teardown; such a session lingers until an explicit close or

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -47,6 +47,8 @@ it has the longest lead time.
   status via a `:describe-fn`.
 - Done: **C1** - closing a session tears down an active ClojureScript repl-env,
   via the session's `:close` metadata hook.
+- Done: **C2** - `load-file` evaluates the source sent in the message (unsaved
+  buffers included) instead of re-reading from disk.
 
 ## Phase 1 - Seams and small modernizations
 
@@ -119,7 +121,7 @@ killed, client exit). Today the node subprocess or browser connection leaks.
 - Risk: low to moderate. Needs care around nREPL session lifecycle hooks and not
   double-tearing-down on a normal quit. Add a regression test.
 
-### C2 - `load-file` evaluates the sent content
+### C2 - `load-file` evaluates the sent content (done)
 
 Make `load-file` compile the source provided in the message against the right
 namespace and path, rather than re-reading the file from disk. This matches

--- a/src/cider/piggieback/cljs.clj
+++ b/src/cider/piggieback/cljs.clj
@@ -243,6 +243,18 @@
     form)
    opts))
 
+(defn load-source
+  "Load ClojureScript `source` (a string of one or more forms) as if it were the
+  file at `filename`, evaluating each form in `repl-env`.
+
+  Unlike `cljs.repl/load-file`, this loads the source handed to it rather than
+  reading the file from disk, so unsaved editor buffers load correctly. The
+  current analyzer namespace is restored afterwards, matching the behaviour of
+  `cljs.repl/load-file`."
+  [repl-env source filename]
+  (binding [ana/*cljs-ns* ana/*cljs-ns*]
+    (cljs.repl/load-stream repl-env filename (StringReader. source))))
+
 ;; ---------------------------------------------------------------------------
 ;; REPL setup
 ;; ---------------------------------------------------------------------------

--- a/src/cider/piggieback_impl.clj
+++ b/src/cider/piggieback_impl.clj
@@ -288,16 +288,40 @@
                                               :value "nil"
                                               :ns (str orig-ns))))))
 
-;; struggled for too long trying to interface directly with cljs.repl/load-file,
-;; so just mocking a "regular" load-file call
-;; this seems to work perfectly, *but* it only loads the content of the file from
-;; disk, not the content of the file sent in the message (in contrast to nREPL on
-;; Clojure). This is necessitated by the expectation of cljs.repl/load-file that
-;; the file being loaded is on disk, in the location implied by the namespace
-;; declaration.
-;; TODO: Either pull in our own `load-file` that doesn't imply this, or raise the issue upstream.
-(defn- load-file [{:keys [session transport file-path] :as msg}]
-  (evaluate (assoc msg :code (format "(load-file %s)" (pr-str file-path)))))
+(defn- do-load-file
+  "Evaluate the ClojureScript source sent in the `load-file` message (its
+  `:file`), against the active repl-env. Mirrors the binding setup of `do-eval`."
+  [{:keys [session transport file file-path file-name] :as msg}]
+  (with-bindings (merge (core/eval-bindings (get @session #'*cljs-compiler-env*)
+                                            (get @session #'*cljs-repl-env*))
+                        ;; On nREPL 1.3+ the session middleware already binds the
+                        ;; session contents, so we must not rebind them here.
+                        (when-not compat/nrepl-1-3+?
+                          @session)
+                        (compat/output-bindings msg))
+    ;; Repoint the repl env's output-pump thread at this message's output (#111).
+    (when *cljs-out-target* (reset! *cljs-out-target* *out*))
+    (when *cljs-err-target* (reset! *cljs-err-target* *err*))
+    (let [repl-env *cljs-repl-env*
+          repl-options *cljs-repl-options*]
+      (try
+        (core/load-source repl-env file (or file-path file-name "<cljs file>"))
+        (.flush ^Writer *out*)
+        (.flush ^Writer *err*)
+        (transport/send transport (response-for msg
+                                                :value "nil"
+                                                :ns (str (core/current-ns))))
+        (catch Throwable t
+          (repl-caught session transport msg t repl-env repl-options))))))
+
+(defn- load-file [{:keys [file file-path] :as msg}]
+  (if (string? file)
+    ;; Evaluate the source sent in the message, so unsaved buffers load
+    ;; correctly (matching nREPL's behaviour on Clojure).
+    (do-load-file msg)
+    ;; No content was sent: fall back to loading the file from disk via the cljs
+    ;; `load-file` special function.
+    (evaluate (assoc msg :code (format "(load-file %s)" (pr-str file-path))))))
 
 (defn describe-cljs
   "A describe-fn (see nREPL's `wrap-describe`) that contributes Piggieback's

--- a/test/cider/piggieback_test.clj
+++ b/test/cider/piggieback_test.clj
@@ -124,6 +124,29 @@
       (is (= "active" (:cljs-repl pb)))
       (is (= "cljs.repl.node.NodeEnv" (:repl-env-type pb))))))
 
+;; load-file must evaluate the source *sent in the message* (an editor buffer,
+;; possibly unsaved), not re-read the file from disk. Here the file path points
+;; nowhere on disk, so this only passes if the content is what gets loaded.
+(deftest load-file-evaluates-sent-content
+  (let [content (nrepl/code
+                 (ns piggieback.load-test)
+                 (defn answer [] 42))
+        response (-> (nrepl/message *session*
+                                    {:op "load-file" :file content
+                                     :file-path "nonexistent/piggieback/load_test.cljs"
+                                     :file-name "load_test.cljs"})
+                     nrepl/combine-responses)]
+    (testing (pr-str response)
+      (some-> response :err println)
+      (is (contains? (:status response) "done"))
+      (is (not (contains? (:status response) "eval-error")))))
+  ;; the namespace and var defined by the loaded buffer are now available
+  (let [response (-> (nrepl/message *session* {:op "eval" :code "(piggieback.load-test/answer)"})
+                     nrepl/combine-responses)]
+    (testing (pr-str response)
+      (some-> response :err println)
+      (is (= ["42"] (:value response))))))
+
 ;; The forwarding writer stands in for *out*/*err* while the repl env is set up,
 ;; so it must cope with every way Clojure and the repl env write to it, not just
 ;; the (char[], off, len) arity the Node output pump happens to use.


### PR DESCRIPTION
Roadmap item C2, resolving a long-standing TODO.

Piggieback's `load-file` used to re-read the file from `:file-path` on disk, so loading an unsaved editor buffer silently loaded the last-saved version instead. It now evaluates the `:file` content sent in the message via `cljs.repl/load-stream` (which reads and evaluates every top-level form), restoring the analyzer namespace afterwards just like `cljs.repl/load-file` does. This matches nREPL's behaviour on Clojure.

If a message arrives without `:file` content, it falls back to the old disk-based `load-file` special function.

Tested against the node fixture by loading buffer content whose `:file-path` points nowhere on disk, then calling the defined var. Verified across nREPL 1.0/1.7 and ClojureScript 1.11/1.12.