### PR TITLE
Tame the repl* setup warts (single delegator, no :print side-channel)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -159,19 +159,21 @@ sequenceDiagram
     W->>IE: pass through
     IE->>PB: invoke cljs-repl
     PB->>PB: wrap repl-env in a delegating env,<br/>build default-compiler-env up front
-    PB->>R: run-cljs-repl (ns-require form + " :cljs/quit")
+    PB->>R: setup-repl (ns-require form + " :cljs/quit")
     R->>E: -setup
     E->>JS: launch runtime
-    R-->>PB: :print callback records compiler-env
-    PB->>PB: set! dynamic vars, switch *ns* to cljs.user
+    R-->>PB: repl* loop exits on :cljs/quit
+    PB->>PB: set! dynamic vars, swap session ns to cljs.user
     PB-->>C: "To quit, type: :cljs/quit"
 ```
 
 Setup is the one place Piggieback drives `cljs.repl/repl*` (the full REPL loop)
 rather than evaluating forms itself. It feeds the loop a single namespace-require
-form plus `:cljs/quit`, with no-op `:prompt` / `:need-prompt` / `:init`
-callbacks, and reaches the compiler env back out through the `:print` callback.
-The compiler env is also created up front and captured unconditionally, so that
+form plus `:cljs/quit`, with no-op `:prompt` / `:need-prompt` / `:init` / `:print`
+callbacks. Afterwards Piggieback reads the state it needs back directly: the
+compiler env is the one it created and handed in, and the namespace is always
+`cljs.user` (the setup form switches into it), so no `:print` side-channel is
+needed. The compiler env is created up front and captured unconditionally, so that
 evaluation still works even if the setup eval errors before `:print` runs (issue
 #62).
 
@@ -212,8 +214,11 @@ re-reads with an EDN reader (using `UnknownTaggedLiteral` as the default tag
 handler so unknown tagged literals round-trip) before sending it as `:value`.
 
 Note the two distinct evaluation paths (setup via `repl*`, steady-state via
-`evaluate-form`). That split is the source of much of Piggieback's incidental
-complexity and is the target of the largest planned refactor (roadmap item B1).
+`evaluate-form`). Fully unifying them onto one path was considered (roadmap item
+B1) but deferred: it would mean replicating `repl*`'s version-sensitive setup,
+trading one coupling for another. Instead the worst of the setup warts were
+removed (the `:print` side-channel, and the per-class codegen delegator described
+below), keeping `repl*` for the setup it does correctly.
 
 ### Session REPL state and teardown
 
@@ -256,11 +261,18 @@ These are the non-obvious pieces that make the bridge work.
 
 `cljs.repl/repl*` calls `-tear-down` on the repl-env when its loop exits, which
 (because setup appends `:cljs/quit`) would tear the env down immediately after
-setup. To prevent that, Piggieback wraps the real repl-env in a generated
-"delegating" type whose `-tear-down` is a no-op and which forwards every other
-`IJavaScriptEnv` method (and map-like access) to the wrapped env. The wrapper is
-currently generated per repl-env class at runtime via `eval`. Removing the
-`repl*` driving would remove the need for this wrapper entirely (roadmap B1).
+setup. To prevent that, Piggieback wraps the real repl-env in a single
+`DelegatingReplEnv` type whose `-tear-down` is a no-op and which forwards every
+other `IJavaScriptEnv` method (and map-like access) to the wrapped env.
+
+The `cljs.repl` error-formatting protocols (`IParseError`, `IGetError`,
+`IParseStacktrace`, `IPrintStacktrace`, `IReplEnvOptions`) are optional - a given
+env implements only some (node and the browser env implement different subsets) -
+and `cljs.repl` guards each call site with `satisfies?`. The delegator implements
+all of them, delegating to the wrapped env when it supports the protocol and
+otherwise falling back to the same default `cljs.repl` would use, so it mirrors
+each env's behaviour per instance. This replaced an earlier scheme that generated
+a delegating type per repl-env class at runtime via `eval` (roadmap item B1).
 
 ### Output forwarding (issue #111)
 
@@ -342,6 +354,5 @@ Piggieback also couples tightly to ClojureScript compiler internals
 non-public parts of `cljs.repl`). This is largely unavoidable given there is no
 public "evaluate a cljs form in this env and hand me the result" API, but it is
 fragile, so it is confined to a single namespace, `cider.piggieback.cljs`, which
-exposes a small Clojure-facing API the middleware talks to instead of reaching
-into the compiler directly (roadmap item M2). That boundary is also what makes
-the planned evaluation-ownership refactor (B1) tractable.
+holds all of it; the public `cider.piggieback` namespace reaches none of the
+compiler directly (roadmap item M2).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -53,6 +53,10 @@ it has the longest lead time.
   now a public `cider.piggieback` namespace that lazily loads the
   `cider.piggieback.cljs` implementation, and the clj-kondo workarounds it
   forced are removed.
+- Done: **B1 (pragmatic scope)** - removed the worst setup warts: the per-class
+  `eval`-codegen delegating env is now a single `DelegatingReplEnv` type, and the
+  `:print` side-channel is gone (the session ns is set explicitly after setup).
+  Full setup-ownership was deferred (see below).
 
 ## Phase 1 - Seams and small modernizations
 
@@ -151,22 +155,39 @@ returns a no-op middleware when ClojureScript is absent.
 
 ## Phase 4 - The core refactor
 
-### B1 - Own evaluation; remove the `repl*` driving and the codegen delegator
+### B1 - Tame the `repl*` setup warts (pragmatic scope, done)
 
-Stop driving `cljs.repl/repl*` for setup. Instead: run `-setup` once, establish
-the analyzer/compiler bindings explicitly, run the initial requires as an ordinary
-`evaluate-form`, and use one uniform evaluation path for everything. This
-collapses the two evaluation paths into one, removes the `:print`-callback
-side-channel for reaching compiler state, and eliminates the runtime-generated
-delegating repl-env (which exists only to swallow the `-tear-down` that `repl*`
-would otherwise trigger after setup).
+The original plan was to stop driving `cljs.repl/repl*` for setup entirely: run
+`-setup` once, establish the analyzer/compiler bindings explicitly, run the
+initial requires as an ordinary `evaluate-form`, and use one uniform evaluation
+path for everything. Investigating it showed that owning setup means replicating
+`repl*`'s version-sensitive setup block (the analyzer bindings, the warnings
+merge, `with-core-cljs`/`-setup`, `merge-opts`) - trading coupling to `repl*`'s
+loop for coupling to its setup internals, with the matrix only exercising the
+Node env.
 
-- Why: this split is the root cause of most of Piggieback's historical bugs
-  (compiler-env capture, output routing, ns tracking). Unifying the path is what
-  stops the next decade of the same class of bug.
-- Risk: high. This is the riskiest change in the plan. Do it on a branch, behind
-  the full CI matrix, after M1 and M2 have established clean seams.
-- Depends on: M1, M2.
+So the pragmatic subset was done instead, keeping `repl*` for the setup it does
+correctly while removing the two warts that don't earn their keep:
+
+- The per-class `eval`-codegen delegating env became a single `DelegatingReplEnv`
+  type. The optional `cljs.repl` protocols are delegated to the wrapped env when
+  it implements them and otherwise fall back to `cljs.repl`'s own default, so one
+  type mirrors each env per instance without generating a class per env class.
+- The `:print` side-channel is gone. The `#62` fix already meant the compiler env
+  is created up front and captured unconditionally; the post-setup namespace is
+  always `cljs.user`, so the session ns is set explicitly after setup rather than
+  smuggled out through `:print`.
+
+### B1-full - Own setup outright (deferred)
+
+Still open, if the appetite and broader env coverage (browser, graal) arrive:
+fully replicate setup and collapse to a single evaluation path, deleting the
+delegating env entirely.
+
+- Why: a single eval path is conceptually cleaner and removes the last need for
+  the delegating env.
+- Risk: high, and it replicates fragile `repl*` internals; the pragmatic scope
+  already captured most of the maintainability win at low risk.
 
 ## Phase 5 - Upstream work
 

--- a/src/cider/piggieback/cljs.clj
+++ b/src/cider/piggieback/cljs.clj
@@ -11,6 +11,7 @@
   `UnknownTaggedLiteral`) live in `cider.piggieback`, referred to here as `pb`."
   (:refer-clojure :exclude [load-file])
   (:require
+   [clojure.edn :as edn]
    [clojure.main]
    [clojure.string :as string]
    [clojure.tools.reader :as reader]
@@ -116,65 +117,79 @@
 (defprotocol GetReplEnv
   (get-repl-env [this]))
 
-(def ^:private cljs-repl-protocol-impls
-  {cljs.repl/IReplEnvOptions
-   {:-repl-options (fn [repl-env] (cljs.repl/-repl-options (get-repl-env repl-env)))}
-   cljs.repl/IParseError
-   {:-parse-error (fn [repl-env err build-options]
-                    (cljs.repl/-parse-error (get-repl-env repl-env) err build-options))}
-   cljs.repl/IGetError
-   {:-get-error (fn [repl-env name env build-options]
-                  (cljs.repl/-get-error (get-repl-env repl-env) name env build-options))}
-   cljs.repl/IParseStacktrace
-   {:-parse-stacktrace (fn [repl-env stacktrace err build-options]
-                         (cljs.repl/-parse-stacktrace (get-repl-env repl-env) stacktrace err build-options))}
-   cljs.repl/IPrintStacktrace
-   {:-print-stacktrace (fn [repl-env stacktrace err build-options]
-                         (cljs.repl/-print-stacktrace (get-repl-env repl-env) stacktrace err build-options))}})
+(declare delegating-repl-env)
 
-(defn- generate-delegating-repl-env [repl-env]
-  (let [repl-env-class (class repl-env)
-        classname (string/replace (.getName repl-env-class) \. \_)
-        dclassname (str "Delegating" classname)]
-    (eval
-     (list*
-      'deftype (symbol dclassname)
-      '([repl-env]
-        cider.piggieback.cljs/GetReplEnv
-        (get-repl-env [this] (.-repl-env this))
-        cljs.repl/IJavaScriptEnv
-        (-setup [this options] (cljs.repl/-setup repl-env options))
-        (-evaluate [this a b c] (cljs.repl/-evaluate repl-env a b c))
-        (-load [this ns url] (cljs.repl/-load repl-env ns url))
-        ;; This is the whole reason we are creating this delegator
-        ;; to prevent the call to tear-down
-        (-tear-down [_])
-        clojure.lang.ILookup
-        (valAt [_ k] (get repl-env k))
-        (valAt [_ k default] (get repl-env k default))
-        clojure.lang.Seqable
-        (seq [_] (seq repl-env))
-        clojure.lang.Associative
-        (containsKey [_ k] (contains? repl-env k))
-        (entryAt [_ k] (find repl-env k))
-        (assoc [_ k v] (#'cider.piggieback.cljs/delegating-repl-env (assoc repl-env k v)))
-        clojure.lang.IPersistentCollection
-        (count [_] (count repl-env))
-        (cons [_ entry] (conj repl-env entry))
-        ;; pretty meaningless; most REPL envs are records for the assoc'ing, but they're not values
-        (equiv [_ other] false))))
-    (let [dclass (resolve (symbol dclassname))
-          ctor (resolve (symbol (str "->" dclassname)))]
-      (doseq [[protocol fn-map] cljs-repl-protocol-impls]
-        (when (satisfies? protocol repl-env)
-          (extend dclass protocol fn-map)))
-      @ctor)))
+;; The optional `cljs.repl` protocols (everything but `IJavaScriptEnv`) are
+;; delegated to the wrapped env when it implements them, and otherwise fall back
+;; to the exact default behaviour `cljs.repl` itself uses at the call site (every
+;; one of these is guarded there by `satisfies?`). That way a single type mirrors,
+;; per instance, whichever subset a given env supports - node and the browser env,
+;; for example, implement different subsets - without generating a class per env.
+(deftype ^:private DelegatingReplEnv [repl-env]
+  GetReplEnv
+  (get-repl-env [_] repl-env)
+
+  cljs.repl/IJavaScriptEnv
+  (-setup [_ opts] (cljs.repl/-setup repl-env opts))
+  (-evaluate [_ filename line js] (cljs.repl/-evaluate repl-env filename line js))
+  (-load [_ provides url] (cljs.repl/-load repl-env provides url))
+  ;; the whole reason this type exists: swallow the tear-down repl* triggers
+  (-tear-down [_])
+
+  cljs.repl/IReplEnvOptions
+  (-repl-options [_]
+    (if (satisfies? cljs.repl/IReplEnvOptions repl-env)
+      (cljs.repl/-repl-options repl-env)
+      {}))
+
+  cljs.repl/IParseError
+  (-parse-error [_ err build-options]
+    (if (satisfies? cljs.repl/IParseError repl-env)
+      (cljs.repl/-parse-error repl-env err build-options)
+      err))
+
+  cljs.repl/IGetError
+  (-get-error [_ name env build-options]
+    (if (satisfies? cljs.repl/IGetError repl-env)
+      (cljs.repl/-get-error repl-env name env build-options)
+      (edn/read-string
+       (cljs.repl/evaluate-form repl-env env "<cljs repl>"
+                                `(when ~name
+                                   (pr-str {:value (str ~name)
+                                            :stacktrace (.-stack ~name)}))))))
+
+  cljs.repl/IParseStacktrace
+  (-parse-stacktrace [_ stacktrace err build-options]
+    (when (satisfies? cljs.repl/IParseStacktrace repl-env)
+      (cljs.repl/-parse-stacktrace repl-env stacktrace err build-options)))
+
+  cljs.repl/IPrintStacktrace
+  (-print-stacktrace [_ stacktrace err build-options]
+    (if (satisfies? cljs.repl/IPrintStacktrace repl-env)
+      (cljs.repl/-print-stacktrace repl-env stacktrace err build-options)
+      (#'cljs.repl/print-mapped-stacktrace stacktrace build-options)))
+
+  ;; repl-envs are treated as maps (opts are assoc'd, keys are read), so delegate
+  ;; map access to the wrapped env.
+  clojure.lang.ILookup
+  (valAt [_ k] (get repl-env k))
+  (valAt [_ k default] (get repl-env k default))
+  clojure.lang.Seqable
+  (seq [_] (seq repl-env))
+  clojure.lang.Associative
+  (containsKey [_ k] (contains? repl-env k))
+  (entryAt [_ k] (find repl-env k))
+  (assoc [_ k v] (delegating-repl-env (assoc repl-env k v)))
+  clojure.lang.IPersistentCollection
+  (count [_] (count repl-env))
+  (cons [_ entry] (conj repl-env entry))
+  ;; pretty meaningless; most REPL envs are records for the assoc'ing, but they're not values
+  (equiv [_ _other] false))
 
 (defn delegating-repl-env
   "Wrap `repl-env` in a delegating env with a no-op `-tear-down`."
   [repl-env]
-  (let [ctor (generate-delegating-repl-env repl-env)]
-    (ctor repl-env)))
+  (->DelegatingReplEnv repl-env))
 
 (defn tear-down!
   "Tear down the (unwrapped) repl env."
@@ -272,13 +287,14 @@
 
 (defn setup-repl
   "Drive `cljs.repl/repl*` through a single setup form (the `cljs.user`
-  namespace require), starting from analyzer namespace `init-ns`. After the
-  setup eval, `on-setup` is called with the resulting analyzer namespace and the
-  compiler env, so the caller can persist them.
+  namespace require), starting from analyzer namespace `init-ns`.
 
   This is the one place we drive the full `repl*` loop rather than evaluating
-  forms ourselves; everything else goes through `eval-form`."
-  [repl-env compiler-env options init-ns code on-setup]
+  forms ourselves; everything else goes through `eval-form`. The setup form
+  always switches into `cljs.user`, and the compiler env is the one we passed in,
+  so the caller can read both back directly after this returns - no callback or
+  `:print` side-channel needed."
+  [repl-env compiler-env options init-ns code]
   (binding [ana/*cljs-ns* init-ns]
     (with-in-str (str code " :cljs/quit")
       (cljs.repl/repl*
@@ -294,8 +310,8 @@
          :prompt (fn [])
          :bind-err false
          :quit-prompt (fn [])
-         :print (fn [_result & _rest]
-                  (on-setup ana/*cljs-ns* env/*compiler*))})))))
+         ;; discard the setup form's printed result
+         :print (fn [_result & _rest])})))))
 
 ;; ---------------------------------------------------------------------------
 ;; nREPL handlers
@@ -394,16 +410,17 @@
              (nrepl/code (ns cljs.user
                            (:require [cljs.repl :refer-macros [source doc find-doc
                                                                apropos dir pst]]
-                                     [cljs.pprint]))))
-           ;; implicitly records the compiler env and tracks the namespace
-           (fn [result-ns result-compiler-env]
-             (when (or (not ns) (not= init-ns result-ns))
-               (swap! session assoc ns-var result-ns))
-             (set! pb/*cljs-compiler-env* result-compiler-env))))
+                                     [cljs.pprint]))))))
         (set! pb/*cljs-out-target* out-target)
         (set! pb/*cljs-err-target* err-target))
-      ;; Record the compiler env unconditionally, in case the setup eval errored
-      ;; and the on-setup callback never set it (issue #62).
+      ;; The setup form above switched us into cljs.user; persist that in the
+      ;; session so subsequent evaluations start there. (Setting `ns-var` outside
+      ;; of `setup-repl`'s binding works because we `set-current-ns!`'d to
+      ;; cljs.user before it, so the analyzer ns reverts to cljs.user when
+      ;; `repl*`'s own binding unwinds.)
+      (swap! session assoc ns-var (current-ns))
+      ;; Record the compiler env (the one we created and handed to repl*), even
+      ;; if the setup eval errored (issue #62).
       (set! pb/*cljs-compiler-env* compiler-env)
       (set! pb/*cljs-repl-env* repl-env)
       (set! pb/*cljs-repl-options* opts)

--- a/test/cider/piggieback_test.clj
+++ b/test/cider/piggieback_test.clj
@@ -112,6 +112,20 @@
     (testing (pr-str response)
       (is (= "cljs.user" (:ns response))))))
 
+;; A throwing evaluation must be reported as an eval error (this exercises the
+;; delegating repl-env's error-formatting protocols, since cljs.repl's
+;; display-error reaches for them), and the session must keep working afterwards.
+(deftest eval-error-is-reported-and-recoverable
+  (let [response (-> (nrepl/message *session* {:op "eval" :code "(throw (js/Error. \"boom\"))"})
+                     nrepl/combine-responses)]
+    (testing (pr-str response)
+      (is (contains? (:status response) "eval-error"))))
+  (let [response (-> (nrepl/message *session* {:op "eval" :code "(+ 1 1)"})
+                     nrepl/combine-responses)]
+    (testing (pr-str response)
+      (some-> response :err println)
+      (is (= ["2"] (:value response))))))
+
 ;; Piggieback contributes its per-session ClojureScript status to nREPL's
 ;; `describe` response, so tooling can detect cljs mode from the protocol rather
 ;; than inferring it. The fixture has an active node REPL, so describe should


### PR DESCRIPTION
Roadmap item B1, pragmatic scope (owning setup outright would replicate repl*'s version-sensitive internals for little gain, so it's deferred; this removes the two warts that don't earn their keep).

The delegating repl-env used to be generated per repl-env class at runtime via `eval` (compiling a class per env type). It's now one `DelegatingReplEnv`. The wrinkle is that the optional `cljs.repl` protocols are implemented by different envs in different subsets (node has `IParseError`; the browser env has `IGetError`+`IParseStacktrace`), and `cljs.repl` guards each call site with `satisfies?`. So the delegator implements all of them, delegating to the wrapped env when it supports the protocol and otherwise falling back to the exact default `cljs.repl` uses - mirroring each env per instance, no codegen.

The :print side-channel existed to capture the post-setup ns and compiler env out of `repl*` before its bindings unwind. But the #62 fix already captures the compiler env up front, and the setup form always switches into `cljs.user`, so the session ns is just set explicitly after setup.

Added a test that a throwing eval is reported as an eval-error and the session keeps working (exercises the delegator's error-formatting path on node). Verified across nREPL 1.0/1.7, ClojureScript 1.10/1.11/1.12, and the no-ClojureScript no-op path.
